### PR TITLE
Only calculate time for current record if it hasn't ended

### DIFF
--- a/cli/status.go
+++ b/cli/status.go
@@ -25,14 +25,20 @@ func statusCommand(t *core.Timetrace) *cobra.Command {
 
 			project := defaultString
 
-			if report.Current.Project != nil {
+			if report.Current != nil {
 				project = report.Current.Project.Key
+			}
+
+			trackedTimeCurrent := defaultString
+
+			if report.TrackedTimeCurrent != nil {
+				trackedTimeCurrent = report.TrackedTimeCurrent.String()
 			}
 
 			rows := [][]string{
 				{
 					project,
-					report.TrackedTimeCurrent.String(),
+					trackedTimeCurrent,
 					report.TrackedTimeToday.String(),
 				},
 			}

--- a/core/record.go
+++ b/core/record.go
@@ -74,11 +74,7 @@ func (t *Timetrace) DeleteRecord(record Record) error {
 // loadLatestRecord loads the youngest record. This may also be a record from
 // another day. If there is no latest record, nil and no error will be returned.
 func (t *Timetrace) loadLatestRecord() (*Record, error) {
-	latestDirs, err := t.fs.RecordDirs(func(a, b string) bool {
-		dateA, _ := time.Parse("2006-01-02", a)
-		dateB, _ := time.Parse("2006-01-02", a)
-		return dateA.Before(dateB)
-	})
+	latestDirs, err := t.fs.RecordDirs()
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +83,7 @@ func (t *Timetrace) loadLatestRecord() (*Record, error) {
 		return nil, nil
 	}
 
-	dir := latestDirs[0]
+	dir := latestDirs[len(latestDirs)-1]
 
 	latestRecords, err := t.fs.RecordFilepaths(dir, func(a, b string) bool {
 		timeA, _ := time.Parse(recordLayout, a)

--- a/core/timetrace.go
+++ b/core/timetrace.go
@@ -97,19 +97,23 @@ func (t *Timetrace) Status() (*Report, error) {
 		return nil, err
 	}
 
-	report := &Report{
-		TrackedTimeToday: now.Sub(firstRecord.Start),
+	var report Report
+
+	// If the latest record has been stopped, there is no "current record".
+	// Therefore, just calculate the tracked time of today and return.
+	if latestRecord.End != nil {
+		return &Report{
+			TrackedTimeToday: latestRecord.End.Sub(firstRecord.Start),
+		}, nil
 	}
 
-	// If the latest record hasn't ended yet, it is the current record.
-	// Set information related to the current record.
-	if latestRecord.End == nil {
-		report.Current = latestRecord
-		trackedTimeCurrent := now.Sub(*latestRecord.End)
-		report.TrackedTimeCurrent = &trackedTimeCurrent
-	}
+	report.Current = latestRecord
 
-	return report, nil
+	// If the latest record has not been stopped, time is still being tracked.
+	trackedTimeCurrent := now.Sub(*latestRecord.End)
+	report.TrackedTimeCurrent = &trackedTimeCurrent
+
+	return &report, nil
 }
 
 // Stop stops the time tracking and marks the current record as ended.

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -112,28 +112,12 @@ func (fs *Fs) RecordFilepaths(dir string, less func(a, b string) bool) ([]string
 	return filepaths, nil
 }
 
-// RecordDirs returns all record directories sorted by the given function.
-//
-// For example, assume three directories containing record files:
-//
-//	- timetrace/records/2021-05-01
-//	- timetrace/records/2021-05-02
-//	- timetrace/records/2021-05-03
-//
-// The following call to RecordDirs will return those directories sorted from
-// newest to oldest:
-//
-//	latestRecordDirs, err := RecordDirs(func (a, b string) bool {
-//		dateA, _ := time.Parse("2006-01-02", a)
-//		dateB, _ := time.Parse("2006-01-02", b)
-//		return dateA.Before(dateB)
-//	})
-//
-// This can be used to determine the latest record directory and obtain the
-// latest record within that directory using RecordFilepaths.
+// RecordDirs returns all record directories sorted alphabetically. This can be
+// used to determine the latest record directory and obtain the latest record
+// within that directory using RecordFilepaths.
 //
 // Note that all timetrace directories have to exist for RecordDirs to work.
-func (fs *Fs) RecordDirs(less func(a, b string) bool) ([]string, error) {
+func (fs *Fs) RecordDirs() ([]string, error) {
 	items, err := ioutil.ReadDir(fs.recordsDir())
 	if err != nil {
 		return nil, err
@@ -148,9 +132,7 @@ func (fs *Fs) RecordDirs(less func(a, b string) bool) ([]string, error) {
 		dirs = append(dirs, filepath.Join(fs.recordsDir(), item.Name()))
 	}
 
-	sort.Slice(dirs, func(i, j int) bool {
-		return less(dirs[i], dirs[j])
-	})
+	sort.Strings(dirs)
 
 	return dirs, nil
 }


### PR DESCRIPTION
Fixes #4. With this PR, the tracked time displayed with `timetrace status` is only calculcated using `time.Now()` if it hasn't ended.