### PR TITLE
Sanitize project key when requesting a project filepath

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/dominikbraun/timetrace/config"
@@ -23,15 +24,20 @@ const (
 )
 
 type Fs struct {
-	config *config.Config
+	config    *config.Config
+	sanitizer *strings.Replacer
 }
 
 func New(config *config.Config) *Fs {
-	return &Fs{config: config}
+	return &Fs{
+		config:    config,
+		sanitizer: strings.NewReplacer("/", "-", "\\", "-"),
+	}
 }
 
 // ProjectFilepath returns the filepath of the project with the given key.
 func (fs *Fs) ProjectFilepath(key string) string {
+	key = fs.sanitizer.Replace(key)
 	name := fmt.Sprintf("%s.json", key)
 	return filepath.Join(fs.projectsDir(), name)
 }


### PR DESCRIPTION
Fixes #8.

This will allow project keys to contain slashes and back-slashes, which would normally cause problems when they're part of the filepath.