### PR TITLE
Fix calculation of total tracked time

### DIFF
--- a/core/record.go
+++ b/core/record.go
@@ -71,6 +71,29 @@ func (t *Timetrace) DeleteRecord(record Record) error {
 	return os.Remove(path)
 }
 
+func (t *Timetrace) loadAllRecords(date time.Time) ([]*Record, error) {
+	dir := t.fs.RecordDirFromDate(date)
+
+	recordFilepaths, err := t.fs.RecordFilepaths(dir, func(a, b string) bool {
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var records []*Record
+
+	for _, recordFilepath := range recordFilepaths {
+		record, err := t.loadRecord(recordFilepath)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+
+	return records, nil
+}
+
 // loadLatestRecord loads the youngest record. This may also be a record from
 // another day. If there is no latest record, nil and no error will be returned.
 func (t *Timetrace) loadLatestRecord() (*Record, error) {


### PR DESCRIPTION
This PR fixes the calculation of the total tracked time when calling `timetrace status`.