### PR TITLE
closes #14: added func returning init dir for empty records dir

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -154,6 +154,7 @@ func (fs *Fs) EnsureDirectories() error {
 	dirs := []string{
 		fs.projectsDir(),
 		fs.recordsDir(),
+		fs.recordsInitSubDir(),
 	}
 
 	for _, dir := range dirs {
@@ -179,6 +180,11 @@ func (fs *Fs) projectsDir() string {
 
 func (fs *Fs) recordsDir() string {
 	return filepath.Join(fs.rootDir(), recordsDirName)
+}
+
+func (fs *Fs) recordsInitSubDir() string {
+	currentDate := fs.RecordDirFromDate(time.Now())
+	return filepath.Join(fs.rootDir(), recordsDirName, currentDate)
 }
 
 func (fs *Fs) rootDir() string {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -183,8 +183,7 @@ func (fs *Fs) recordsDir() string {
 }
 
 func (fs *Fs) recordsInitSubDir() string {
-	currentDate := fs.RecordDirFromDate(time.Now())
-	return filepath.Join(fs.rootDir(), recordsDirName, currentDate)
+	return fs.RecordDirFromDate(time.Now())
 }
 
 func (fs *Fs) rootDir() string {


### PR DESCRIPTION
As stated in the issue I added a func returning the init dir for the empty records directory and appended the slice in fs.EnsureDirectories accordingly. func recordsInitSubDir returns `~/.timetrace/records/YYYY-MM-DD`. cmd timetrace status exists now with ErrTrackingNotStarted instead of with the err from ioutil.ReadDir. 