### PR TITLE
closing #6 formating of duration for table output.

### DIFF
--- a/cli/status.go
+++ b/cli/status.go
@@ -32,17 +32,16 @@ func statusCommand(t *core.Timetrace) *cobra.Command {
 			trackedTimeCurrent := defaultString
 
 			if report.TrackedTimeCurrent != nil {
-				trackedTimeCurrent = report.TrackedTimeCurrent.String()
+				trackedTimeCurrent = report.FormatCurrentTime()
 			}
 
 			rows := [][]string{
 				{
 					project,
 					trackedTimeCurrent,
-					report.TrackedTimeToday.String(),
+					report.FormatTodayTime(),
 				},
 			}
-
 			out.Table([]string{"Current project", "Worked since start", "Worked today"}, rows)
 		},
 	}

--- a/core/timetrace.go
+++ b/core/timetrace.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/dominikbraun/timetrace/config"
@@ -166,4 +167,33 @@ func (t *Timetrace) trackedTime(date time.Time) (time.Duration, error) {
 	}
 
 	return trackedTime, nil
+}
+
+// FormatTodayTime returns the formated string of the total
+// time of today follwoing the format convention
+func (report *Report) FormatTodayTime() string {
+	return formatDuration(report.TrackedTimeToday)
+}
+
+// FormatCurrentTime returns the formated string of the current
+// report time follwoing the format convention
+func (report *Report) FormatCurrentTime() string {
+	return formatDuration(*report.TrackedTimeCurrent)
+}
+
+// formatDuration formats the passed duration into a string.
+// The format will be "8h 24min". If the duration is less then 60 secods
+// the format will be "0h 0min 12sec".
+func formatDuration(duration time.Duration) string {
+
+	hours := int64(duration.Hours()) % 60
+	minutes := int64(duration.Minutes()) % 60
+	secods := int64(duration.Seconds()) % 60
+
+	// as by convention if the duarion is < then 60 secods
+	// return "0h 0min Xsec"
+	if hours == 0 && minutes == 0 {
+		return fmt.Sprintf("0h 0min %dsec", secods)
+	}
+	return fmt.Sprintf("%dh %dmin", hours, minutes)
 }

--- a/core/timetrace_test.go
+++ b/core/timetrace_test.go
@@ -1,0 +1,46 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatDuration(t *testing.T) {
+
+	tt := []struct {
+		Duration time.Duration
+		Expected string
+	}{
+		{
+			Duration: time.Duration(12 * time.Second),
+			Expected: "0h 0min 12sec",
+		},
+		{
+			Duration: time.Duration(60 * time.Minute),
+			Expected: "1h 0min",
+		},
+		{
+			Duration: time.Duration(24 * time.Minute),
+			Expected: "0h 24min",
+		},
+		{
+			Duration: time.Duration((60*8 + 24) * time.Minute),
+			Expected: "8h 24min",
+		},
+		{
+			Duration: time.Duration((60*8+24)*time.Minute + 12*time.Second),
+			Expected: "8h 24min",
+		},
+		{
+			Duration: time.Duration(0 * time.Second),
+			Expected: "0h 0min 0sec",
+		},
+	}
+
+	for _, test := range tt {
+		strFormat := formatDuration(test.Duration)
+		if strFormat != test.Expected {
+			t.Fatalf("format error: %s != %s", strFormat, test.Expected)
+		}
+	}
+}


### PR DESCRIPTION
Added two functions on the Report struct which format the duration according to the discussion in the issue. Both functions return the result of `formatDuration` which does the actual formatting. Tests of this function are included.

```
+-----------------+--------------------+--------------+
| CURRENT PROJECT | WORKED SINCE START | WORKED TODAY |
+-----------------+--------------------+--------------+
| timetest        | 0h 0min 5sec       | 1h 6min      |
+-----------------+--------------------+--------------+
```
And over one minute

```
+-----------------+--------------------+--------------+
| CURRENT PROJECT | WORKED SINCE START | WORKED TODAY |
+-----------------+--------------------+--------------+
| timetest        | 0h 1min            | 1h 7min      |
+-----------------+--------------------+--------------+
```
