### PR TITLE
13 delete record command

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,28 @@ Delete a project called `make-coffee`:
 timetrace delete project make-coffee
 ```
 
+### Delete a record
+
+**Syntax:**
+
+```
+timetrace delete record <YYYY-MM-DD-HH-MM>
+```
+
+**Arguments:**
+
+|Argument|Description|
+|-|-|
+|`YYYY-MM-DD-HH-MM`|The start time of the desired record.|
+
+**Example:**
+
+Delete a record created on May 1st 2021, 3:00 PM:
+
+```
+timetrace delete record 2021-05-01-15-00
+```
+
 ### Start tracking
 
 **Syntax:**

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/dominikbraun/timetrace/core"
 	"github.com/dominikbraun/timetrace/out"
 
@@ -17,6 +19,7 @@ func deleteCommand(t *core.Timetrace) *cobra.Command {
 	}
 
 	delete.AddCommand(deleteProjectCommand(t))
+	delete.AddCommand(deleteRecordCommand(t))
 
 	return delete
 }
@@ -43,4 +46,40 @@ func deleteProjectCommand(t *core.Timetrace) *cobra.Command {
 	}
 
 	return deleteProject
+}
+
+func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
+	deleteRecord := &cobra.Command{
+		Use:   "record YYYY-MM-DD-HH-MM",
+		Short: "Delete a record",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			layout := defaultRecordArgLayout
+
+			if t.Config().Use12Hours {
+				layout = "2006-01-02-03-04PM"
+			}
+
+			start, err := time.Parse(layout, args[0])
+			if err != nil {
+				out.Err("Failed to parse date argument: %s", err.Error())
+				return
+			}
+
+			record, err := t.LoadRecord(start)
+			if err != nil {
+				out.Err("Failed to read record: %s", err.Error())
+				return
+			}
+
+			if err := t.DeleteRecord(*record); err != nil {
+				out.Err("Failed to delete %s", err.Error())
+				return
+			}
+
+			out.Success("Deleted record %s", args[0])
+		},
+	}
+
+	return deleteRecord
 }

--- a/cli/get.go
+++ b/cli/get.go
@@ -9,10 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	defaultRecordArgLayout = "2006-01-02-15-04"
-)
-
 func getCommand(t *core.Timetrace) *cobra.Command {
 	get := &cobra.Command{
 		Use:   "get",

--- a/cli/root.go
+++ b/cli/root.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	defaultString = "---"
-	defaultBool   = "no"
+	defaultString          = "---"
+	defaultBool            = "no"
+	defaultRecordArgLayout = "2006-01-02-15-04"
 )
 
 func RootCommand(t *core.Timetrace, version string) *cobra.Command {


### PR DESCRIPTION
This PR adds the command  - `timetrace delete record <YYYY-MM-DD-HH-MM>` for deleting a  record by its start time. And it closes #13 
