### PR TITLE
Add the project name to the output of list records

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -94,14 +94,15 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 					billable = "yes"
 				}
 
-				rows[i] = make([]string, 4)
+				rows[i] = make([]string, 5)
 				rows[i][0] = strconv.Itoa(i + 1)
-				rows[i][1] = record.Start.Format(dateLayout)
-				rows[i][2] = end
-				rows[i][3] = billable
+				rows[i][1] = record.Project.Key
+				rows[i][2] = record.Start.Format(dateLayout)
+				rows[i][3] = end
+				rows[i][4] = billable
 			}
 
-			out.Table([]string{"#", "Start", "End", "Billable"}, rows)
+			out.Table([]string{"#", "Project", "Start", "End", "Billable"}, rows)
 		},
 	}
 


### PR DESCRIPTION
Adds the project name to each record row when you list the records


`timetrace list records YYYY-MM-DD`:
<img width="349" alt="Screen Shot 2021-05-16 at 7 55 01 PM" src="https://user-images.githubusercontent.com/40612461/118417678-391b6600-b683-11eb-82c6-baf2bb00501a.png">


This resolves #23