### PR TITLE
Enabling bash autocompletion for the CLI

### DIFF
--- a/autocompletion/bash/enable.sh
+++ b/autocompletion/bash/enable.sh
@@ -1,0 +1,17 @@
+if [[ -z $TIMETRACE_DIR ]]; then
+	cp -r autocompletion/ $HOME/.timetrace/
+    TIMETRACE_DIR=$HOME/.timetrace
+    cat >> $HOME/.bashrc << EOF
+
+# >>> timetrace initialization >>>
+# Configuration of timetrace for autocompletion
+export TIMETRACE_DIR=\$HOME/.timetrace
+
+if [ -f \$TIMETRACE_DIR/autocompletion/bash/timetrace.sh ]; then
+    . \$TIMETRACE_DIR/autocompletion/bash/timetrace.sh
+fi
+
+# <<< timetrace initialization <<<
+
+EOF
+fi

--- a/autocompletion/bash/timetrace.sh
+++ b/autocompletion/bash/timetrace.sh
@@ -52,8 +52,6 @@ _complete_timetrace () {
                 fi
                 ;;
             esac
-        else
-            echo "$(_get_argc)"
         fi
         ;;
 

--- a/autocompletion/bash/timetrace.sh
+++ b/autocompletion/bash/timetrace.sh
@@ -1,0 +1,83 @@
+# file: timetrace
+# timetrace parameter autocompletion
+
+
+_complete_timetrace () {
+    # regexp that match the first arguments
+    local cmd="${1##*/}"
+    local word=${COMP_WORDS[COMP_CWORD]}
+    local xpat
+    local commands="create delete edit get list help start status stop version"
+    local no_completion="help start status stop version"
+    local flags="-h -v"
+
+    #create, delete, edit 
+    local common_subcommand="project"
+    #get
+    local get_subcommands="project record"
+    #list resources
+    local list_subcommands="projects records"
+
+    # Check to see what command is been executed
+    cur_command=$(_find_command)
+    case "$cmd" in
+    timetrace)
+        if [[ "$(_get_argc)" -eq 1 ]]; then
+            xpat="$commands"
+        elif [[ "$(_get_argc)" -ge 2 ]]; then
+            case "$cur_command" in
+            # create, delete and edit subcommands
+            create | delete | edit)
+                xpat="$common_subcommand"
+                ;;
+
+            # get subcommands
+            get)
+                xpat="$get_subcommands"
+                ;;
+
+            # list subcommands
+            list)
+                xpat="$list_subcommands"
+                ;;
+
+            # commands that support only flags
+            help | start | status | stop | version)
+                xpat="$flags"
+                ;;
+
+            *)
+                if [[ "$(_get_argc)" -eq 2 ]]; then
+                    xpat="$commands"
+                fi
+                ;;
+            esac
+        else
+            echo "$(_get_argc)"
+        fi
+        ;;
+
+    esac
+
+    COMPREPLY=($(compgen -W "$xpat" -- "${word}"))
+}
+
+_find_command () {
+    local line=${COMP_LINE}
+    IFS=' ' read -r -a array <<< "$line"
+    len="${#array[@]}"
+    
+    # check if there's no subcommand
+    if [[ $len -ge 2 ]]; then
+        echo "${array[1]}"
+    fi
+}
+
+_get_argc () {
+    local line=${COMP_LINE}
+    IFS=' ' read -r -a array <<< "$line"
+    len="${#array[@]}"
+    echo "$len"
+}
+
+complete -F _complete_timetrace timetrace

--- a/out/out.go
+++ b/out/out.go
@@ -10,6 +10,16 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
+var (
+	// used for the headers on the tables
+	backgroundColor = []int{
+		tablewriter.BgGreenColor,
+		tablewriter.BgBlackColor,
+		tablewriter.BgRedColor,
+		tablewriter.BgCyanColor,
+	}
+)
+
 // Success prints a colored, formatted success message prefixed with an emoji.
 func Success(format string, a ...interface{}) {
 	p(color.FgGreen, emoji.CheckMark, format, a...)
@@ -34,8 +44,19 @@ func Err(format string, a ...interface{}) {
 func Table(header []string, rows [][]string) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(header)
+	setHeaderColor(table, header)
 	table.AppendBulk(rows)
 	table.Render()
+}
+
+// setHeaderColor set colors for the headers on the table
+func setHeaderColor(table *tablewriter.Table, header []string) {
+	colors := []tablewriter.Colors{}
+	for i := range header {
+		color := tablewriter.Colors{tablewriter.Bold, backgroundColor[i%len(backgroundColor)]}
+		colors = append(colors, color)
+	}
+	table.SetHeaderColor(colors...)
 }
 
 func p(attribute color.Attribute, emoji emoji.Emoji, format string, a ...interface{}) {


### PR DESCRIPTION
This pull request enable bash autocompletion for the CLI. The autocompletion would be triggered when the key <TAB> is pressed; for example:

```bash
timetrace <TAB>
```
If we press <TAB> here, the autocompletion would suggest all the commands on the CLI. Like in the following gif.

![timetrace](https://user-images.githubusercontent.com/48373523/118418002-9ebc2200-b684-11eb-8dc3-aea7a883a2d2.gif)

To allow this behavior the user would run the following command:
```bash
source autocompletion/bash/enable.sh
```