### PR TITLE
List billable records

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -55,7 +55,13 @@ func listProjectsCommand(t *core.Timetrace) *cobra.Command {
 	return listProjects
 }
 
+type listRecordsOptions struct {
+	isOnlyDisplayingBillable bool
+}
+
 func listRecordsCommand(t *core.Timetrace) *cobra.Command {
+	var options listRecordsOptions
+
 	listRecords := &cobra.Command{
 		Use:   "records <YYYY-MM-DD>",
 		Short: "List all records from a date",
@@ -105,6 +111,9 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 			out.Table([]string{"#", "Project", "Start", "End", "Billable"}, rows)
 		},
 	}
+
+	listRecords.Flags().BoolVarP(&options.isOnlyDisplayingBillable, "billable", "b",
+		false, `only display billable records`)
 
 	return listRecords
 }

--- a/cli/list.go
+++ b/cli/list.go
@@ -79,6 +79,10 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 
+			if options.isOnlyDisplayingBillable {
+				records = filterBillableRecords(records)
+			}
+
 			dateLayout := defaultTimeLayout
 
 			if t.Config().Use12Hours {
@@ -116,4 +120,14 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 		false, `only display billable records`)
 
 	return listRecords
+}
+
+func filterBillableRecords(records []*core.Record) []*core.Record {
+	billableRecords := []*core.Record{}
+	for _, record := range records {
+		if record.IsBillable == true {
+			billableRecords = append(billableRecords, record)
+		}
+	}
+	return billableRecords
 }

--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dominikbraun/timetrace/core"
+)
+
+func TestFilterBillableRecords(t *testing.T) {
+
+	tt := []struct {
+		title    string
+		records  []*core.Record
+		expected []*core.Record
+	}{
+		{
+			title: "all records are billable",
+			records: []*core.Record{
+				{Project: &core.Project{Key: "a"}, IsBillable: true},
+				{Project: &core.Project{Key: "b"}, IsBillable: true},
+			},
+			expected: []*core.Record{
+				{Project: &core.Project{Key: "a"}, IsBillable: true},
+				{Project: &core.Project{Key: "b"}, IsBillable: true},
+			},
+		},
+		{
+			title: "no records are billable",
+			records: []*core.Record{
+				{Project: &core.Project{Key: "a"}, IsBillable: false},
+				{Project: &core.Project{Key: "b"}, IsBillable: false},
+			},
+			expected: []*core.Record{},
+		},
+		{
+			title: "half of records are billable",
+			records: []*core.Record{
+				{Project: &core.Project{Key: "a"}, IsBillable: true},
+				{Project: &core.Project{Key: "b"}, IsBillable: true},
+				{Project: &core.Project{Key: "c"}, IsBillable: false},
+				{Project: &core.Project{Key: "d"}, IsBillable: false},
+			},
+			expected: []*core.Record{
+				{Project: &core.Project{Key: "a"}, IsBillable: true},
+				{Project: &core.Project{Key: "b"}, IsBillable: true},
+			},
+		},
+	}
+
+	for _, test := range tt {
+		billableRecords := filterBillableRecords(test.records)
+		if !reflect.DeepEqual(billableRecords, test.expected) {
+			t.Fatalf("error when %s: %v != %v", test.title, billableRecords, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
Add a --billable (-b) flag to `timetrace list records` to only display the billable records

closes #21 