### PR TITLE
28 include record key

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -73,10 +73,10 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 
-			dateLayout := defaultTimeLayout
+			timeLayout := defaultTimeLayout
 
 			if t.Config().Use12Hours {
-				dateLayout = "03:04PM"
+				timeLayout = "03:04PM"
 			}
 
 			rows := make([][]string, len(records))
@@ -85,7 +85,7 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 				end := defaultString
 
 				if record.End != nil {
-					end = record.End.Format(dateLayout)
+					end = record.End.Format(timeLayout)
 				}
 
 				billable := defaultBool
@@ -97,7 +97,7 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 				rows[i] = make([]string, 5)
 				rows[i][0] = strconv.Itoa(i + 1)
 				rows[i][1] = record.Project.Key
-				rows[i][2] = record.Start.Format(dateLayout)
+				rows[i][2] = record.Start.Format(timeLayout)
 				rows[i][3] = end
 				rows[i][4] = billable
 			}

--- a/cli/list.go
+++ b/cli/list.go
@@ -74,9 +74,11 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 			}
 
 			timeLayout := defaultTimeLayout
+			keyLayout := defaultRecordArgLayout
 
 			if t.Config().Use12Hours {
 				timeLayout = "03:04PM"
+				keyLayout = "2006-01-02-03-04PM"
 			}
 
 			rows := make([][]string, len(records))
@@ -94,15 +96,16 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 					billable = "yes"
 				}
 
-				rows[i] = make([]string, 5)
+				rows[i] = make([]string, 6)
 				rows[i][0] = strconv.Itoa(i + 1)
-				rows[i][1] = record.Project.Key
-				rows[i][2] = record.Start.Format(timeLayout)
-				rows[i][3] = end
-				rows[i][4] = billable
+				rows[i][1] = record.Start.Format(keyLayout)
+				rows[i][2] = record.Project.Key
+				rows[i][3] = record.Start.Format(timeLayout)
+				rows[i][4] = end
+				rows[i][5] = billable
 			}
 
-			out.Table([]string{"#", "Project", "Start", "End", "Billable"}, rows)
+			out.Table([]string{"#", "Key", "Project", "Start", "End", "Billable"}, rows)
 		},
 	}
 


### PR DESCRIPTION
`timetrace list records` output now contains the column 'Key'

Example:
<img width="479" alt="Screen Shot 2021-05-17 at 9 58 39 PM" src="https://user-images.githubusercontent.com/40612461/118579030-4441c500-b75b-11eb-81d6-187509a913a8.png">


Resolves #28 