### PR TITLE
Print CLI version using out.Info

### DIFF
--- a/cli/version.go
+++ b/cli/version.go
@@ -11,7 +11,7 @@ func versionCommand(value string) *cobra.Command {
 		Use:   "version",
 		Short: "Display version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			out.Err("timetrace version %s", value)
+			out.Info("timetrace version %s", value)
 		},
 	}
 


### PR DESCRIPTION
This pull request resolves #12 . As stated in #12, running `timetrace version` now uses `out.Info` to print the version information.
