### PR TITLE
Add AUR instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ brew install timetrace
 sudo snap install timetrace --edge
 ```
 
+### AUR
+
+```
+yay -S timetrace-bin
+```
+
 ### Docker
 
 The timetrace Docker image stores all data in the `/data` directory. To persist


### PR DESCRIPTION
I created an AUR package for `timetrace` to make it easy to install on Arch-based Linux distributions:
https://aur.archlinux.org/packages/timetrace-bin/

In the README, I added the instructions for `yay`, but any AUR helper can be used to install the `timetrace-bin` package.