### PR TITLE
Add magenta header color

### DIFF
--- a/out/out.go
+++ b/out/out.go
@@ -13,9 +13,10 @@ import (
 var (
 	// used for the headers on the tables
 	backgroundColor = []int{
+		tablewriter.BgCyanColor,
+		tablewriter.BgMagentaColor,
 		tablewriter.BgGreenColor,
 		tablewriter.BgRedColor,
-		tablewriter.BgCyanColor,
 		tablewriter.BgYellowColor,
 	}
 )


### PR DESCRIPTION
This PR add the `tablewriter.BgMagentaColor` to the list of header colors.