### PR TITLE
implement timetrace edit record command

### DIFF
--- a/cli/edit.go
+++ b/cli/edit.go
@@ -59,6 +59,11 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 		Short: "Edit a record",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			if options.Plus != "" && options.Minus != "" {
+				out.Err("Plus and minus flag can not be combined: %s", errors.New("edit not possible"))
+				return
+			}
+
 			layout := defaultRecordArgLayout
 
 			if t.Config().Use12Hours {
@@ -77,8 +82,6 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 					out.Err("Failed to edit project: %s", err.Error())
 					return
 				}
-			} else if options.Plus != "" && options.Minus != "" {
-				out.Err("Plus and minus flag can not be combined: %s", errors.New("edit not possible"))
 			} else {
 				if err := t.EditRecord(recordTime, options.Plus, options.Minus); err != nil {
 					out.Err("Failed to edit project: %s", err.Error())

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"errors"
+	"time"
+
 	"github.com/dominikbraun/timetrace/core"
 	"github.com/dominikbraun/timetrace/out"
 
@@ -17,6 +20,7 @@ func editCommand(t *core.Timetrace) *cobra.Command {
 	}
 
 	edit.AddCommand(editProjectCommand(t))
+	edit.AddCommand(editRecordCommand(t))
 
 	return edit
 }
@@ -40,4 +44,54 @@ func editProjectCommand(t *core.Timetrace) *cobra.Command {
 	}
 
 	return editProject
+}
+
+type editOptions struct {
+	Plus  string
+	Minus string
+}
+
+func editRecordCommand(t *core.Timetrace) *cobra.Command {
+	var options editOptions
+
+	editRecord := &cobra.Command{
+		Use:   "record <KEY>",
+		Short: "Edit a record",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			layout := defaultRecordArgLayout
+
+			if t.Config().Use12Hours {
+				layout = "2006-01-02-03-04PM"
+			}
+
+			recordTime, err := time.Parse(layout, args[0])
+			if err != nil {
+				out.Err("Failed to parse date argument: %s", err.Error())
+				return
+			}
+
+			if options.Minus == "" && options.Plus == "" {
+				out.Info("Opening %s in default editor", recordTime)
+				if err := t.EditRecordManual(recordTime); err != nil {
+					out.Err("Failed to edit project: %s", err.Error())
+					return
+				}
+			} else if options.Plus != "" && options.Minus != "" {
+				out.Err("Plus and minus flag can not be combined: %s", errors.New("edit not possible"))
+			} else {
+				if err := t.EditRecord(recordTime, options.Plus, options.Minus); err != nil {
+					out.Err("Failed to edit project: %s", err.Error())
+					return
+				}
+			}
+
+			out.Success("Successfully edited %s", recordTime)
+		},
+	}
+
+	editRecord.PersistentFlags().StringVarP(&options.Plus, "plus", "p", "", "Adds the given duration to the end time of the record")
+	editRecord.PersistentFlags().StringVarP(&options.Minus, "minus", "m", "", "Substracts the given duration to the end time of the record")
+
+	return editRecord
 }


### PR DESCRIPTION
I implemented the edit record command as mentioned here: https://github.com/dominikbraun/timetrace/issues/19
As of now, there is no check if the end time contradicts with the start time of another record (still an open question), but the command returns an error if the new end time is before the start time of the record.