### PR TITLE
17 cmd arg syntax

### DIFF
--- a/cli/delete.go
+++ b/cli/delete.go
@@ -56,14 +56,19 @@ func deleteProjectCommand(t *core.Timetrace) *cobra.Command {
 }
 
 func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
+	use12Hours := t.Config().Use12Hours
+	useTimeFormat := "record YYYY-MM-DD-HH-MM"
+	if use12Hours {
+		useTimeFormat = "record YYYY-MM-DD-HH-MMPM"
+	}
 	deleteRecord := &cobra.Command{
-		Use:   "record YYYY-MM-DD-HH-MM",
+		Use:   useTimeFormat,
 		Short: "Delete a record",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			layout := defaultRecordArgLayout
 
-			if t.Config().Use12Hours {
+			if use12Hours {
 				layout = "2006-01-02-03-04PM"
 			}
 

--- a/cli/get.go
+++ b/cli/get.go
@@ -46,14 +46,19 @@ func getProjectCommand(t *core.Timetrace) *cobra.Command {
 }
 
 func getRecordCommand(t *core.Timetrace) *cobra.Command {
+	use12Hours := t.Config().Use12Hours
+	useTimeFormat := "record YYYY-MM-DD-HH-MM"
+	if use12Hours {
+		useTimeFormat = "record YYYY-MM-DD-HH-MMPM"
+	}
 	getRecord := &cobra.Command{
-		Use:   "record YYYY-MM-DD-HH-MM",
+		Use:   useTimeFormat,
 		Short: "Display a record",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			layout := defaultRecordArgLayout
 
-			if t.Config().Use12Hours {
+			if use12Hours {
 				layout = "2006-01-02-03-04PM"
 			}
 			start, err := time.Parse(layout, args[0])


### PR DESCRIPTION
This PR updates the command argument syntax for 'get record' and 'delete record', based on the config.yaml, as per issue #17 