### PR TITLE
Add `--devmode` to Snap installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ brew install timetrace
 ### Snap
 
 ```
-sudo snap install timetrace --edge
+sudo snap install timetrace --edge --devmode
 ```
 
 ### Docker


### PR DESCRIPTION
Since timetrace is officially still in `devmode`, the `--devmode` flag is required for the Snap installation.