### PR TITLE
Consider modules when filtering projects

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -140,10 +140,10 @@ func filterBillableRecords(records []*core.Record) []*core.Record {
 	return billableRecords
 }
 
-func filterProjectRecords(records []*core.Record, projectKey string) []*core.Record {
+func filterProjectRecords(records []*core.Record, key string) []*core.Record {
 	projectRecords := []*core.Record{}
 	for _, record := range records {
-		if strings.Compare(record.Project.Key, projectKey) == 0 {
+		if record.Project.Key == key || record.Project.Parent() == key {
 			projectRecords = append(projectRecords, record)
 		}
 	}

--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -87,8 +87,18 @@ func TestFilterProjectRecords(t *testing.T) {
 			},
 		},
 		{
+			title:  "filter by project module@b",
+			filter: "b",
+			records: []*core.Record{
+				{Project: &core.Project{Key: "module@b"}, IsBillable: false},
+			},
+			expected: []*core.Record{
+				{Project: &core.Project{Key: "module@b"}, IsBillable: false},
+			},
+		},
+		{
 			title:  "no records found",
-			filter: "",
+			filter: "a",
 			records: []*core.Record{
 				{Project: &core.Project{Key: "c"}, IsBillable: false},
 				{Project: &core.Project{Key: "d"}, IsBillable: false},


### PR DESCRIPTION
With this PR, the `--project` filter will take project modules into account - meaning a module `grind-beans@make-coffee` will be included when passing a filter `--project make-coffee`.