### PR TITLE
Migrate to `core.Formatter` for retrieving the configured time formats

### DIFF
--- a/cli/delete.go
+++ b/cli/delete.go
@@ -57,8 +57,8 @@ func deleteProjectCommand(t *core.Timetrace) *cobra.Command {
 func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
 
 	// Depending on the use12hours setting, the command syntax either is
-	// `delete YYYY-MM-DD-HH-MM` or `delete YYYY-MM-DD-HH-MMPM`.
-	use := fmt.Sprintf("delete %s", t.Formatter().RecordKeyLayout())
+	// `record YYYY-MM-DD-HH-MM` or `record YYYY-MM-DD-HH-MMPM`.
+	use := fmt.Sprintf("record %s", t.Formatter().RecordKeyLayout())
 
 	deleteRecord := &cobra.Command{
 		Use:   use,

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -55,13 +55,13 @@ func deleteProjectCommand(t *core.Timetrace) *cobra.Command {
 }
 
 func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
-	use12Hours := t.Config().Use12Hours
-	useTimeFormat := "record YYYY-MM-DD-HH-MM"
-	if use12Hours {
-		useTimeFormat = "record YYYY-MM-DD-HH-MMPM"
-	}
+
+	// Depending on the use12hours setting, the command syntax either is
+	// `delete YYYY-MM-DD-HH-MM` or `delete YYYY-MM-DD-HH-MMPM`.
+	use := fmt.Sprintf("delete %s", t.Formatter().RecordKeyLayout())
+
 	deleteRecord := &cobra.Command{
-		Use:   useTimeFormat,
+		Use:   use,
 		Short: "Delete a record",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -65,7 +65,7 @@ func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
 		Short: "Delete a record",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			start, err := t.Formatter().ParseRecordKeyString(args[0])
+			start, err := t.Formatter().ParseRecordKey(args[0])
 			if err != nil {
 				out.Err("Failed to parse date argument: %s", err.Error())
 				return

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -63,7 +63,7 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 
-			recordTime, err := t.Formatter().ParseRecordKeyString(args[0])
+			recordTime, err := t.Formatter().ParseRecordKey(args[0])
 			if err != nil {
 				out.Err("Failed to parse date argument: %s", err.Error())
 				return

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"time"
 
 	"github.com/dominikbraun/timetrace/core"
 	"github.com/dominikbraun/timetrace/out"
@@ -64,13 +63,7 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 
-			layout := defaultRecordArgLayout
-
-			if t.Config().Use12Hours {
-				layout = "2006-01-02-03-04PM"
-			}
-
-			recordTime, err := time.Parse(layout, args[0])
+			recordTime, err := t.Formatter().ParseRecordKeyString(args[0])
 			if err != nil {
 				out.Err("Failed to parse date argument: %s", err.Error())
 				return

--- a/cli/get.go
+++ b/cli/get.go
@@ -56,7 +56,7 @@ func getRecordCommand(t *core.Timetrace) *cobra.Command {
 		Short: "Display a record",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			start, err := t.Formatter().ParseRecordKeyString(args[0])
+			start, err := t.Formatter().ParseRecordKey(args[0])
 			if err != nil {
 				out.Err("Failed to parse date argument: %s", err.Error())
 				return

--- a/cli/get.go
+++ b/cli/get.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/dominikbraun/timetrace/core"
 	"github.com/dominikbraun/timetrace/out"
 
@@ -44,13 +46,13 @@ func getProjectCommand(t *core.Timetrace) *cobra.Command {
 }
 
 func getRecordCommand(t *core.Timetrace) *cobra.Command {
-	use12Hours := t.Config().Use12Hours
-	useTimeFormat := "record YYYY-MM-DD-HH-MM"
-	if use12Hours {
-		useTimeFormat = "record YYYY-MM-DD-HH-MMPM"
-	}
+
+	// Depending on the use12hours setting, the command syntax either is
+	// `record YYYY-MM-DD-HH-MM` or `record YYYY-MM-DD-HH-MMPM`.
+	use := fmt.Sprintf("record %s", t.Formatter().RecordKeyLayout())
+
 	getRecord := &cobra.Command{
-		Use:   useTimeFormat,
+		Use:   use,
 		Short: "Display a record",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cli/list.go
+++ b/cli/list.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/dominikbraun/timetrace/core"
 	"github.com/dominikbraun/timetrace/out"
@@ -65,20 +64,10 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 		Short: "List all records from a date",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var date time.Time
-			var err error
-
-			switch strings.ToLower(args[0]) {
-			case "today":
-				date = time.Now()
-			case "yesterday":
-				date = time.Now().AddDate(0, 0, -1)
-			default:
-				date, err = time.Parse("2006-01-02", args[0])
-				if err != nil {
-					out.Err("failed to parse date: %s", err.Error())
-					return
-				}
+			date, err := t.Formatter().ParseDate(args[0])
+			if err != nil {
+				out.Err("failed to parse date: %s", err.Error())
+				return
 			}
 
 			records, err := t.ListRecords(date)
@@ -111,7 +100,7 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 
 				rows[i] = make([]string, 6)
 				rows[i][0] = strconv.Itoa(i + 1)
-				rows[i][1] = t.Formatter().RecordKeyString(*record)
+				rows[i][1] = t.Formatter().RecordKey(record)
 				rows[i][2] = record.Project.Key
 				rows[i][3] = t.Formatter().TimeString(record.Start)
 				rows[i][4] = end

--- a/core/formatter.go
+++ b/core/formatter.go
@@ -1,15 +1,39 @@
 package core
 
-import "time"
+import (
+	"time"
+)
+
+// Formatter represents a date- and time formatter. It provides all displayed
+// date- and time layouts and is capable of parsing those layouts.
+type Formatter struct {
+	use12Hours bool
+}
+
+const dateLayout = "2006-01-02"
+
+// ParseDate parses a date from an input string in the form YYYY-MM-DD. It also
+// supports the `today` and `yesterday` aliases for convenience.
+func (f *Formatter) ParseDate(input string) (time.Time, error) {
+	if input == "today" {
+		return time.Now(), nil
+	}
+	if input == "yesterday" {
+		yesterday := time.Now().AddDate(0, 0, -1)
+		return yesterday, nil
+	}
+
+	date, err := time.Parse(dateLayout, input)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return date, nil
+}
 
 const (
 	defaultTimeLayout        = "15:04"
 	default12HoursTimeLayout = "03:04PM"
 )
-
-type Formatter struct {
-	use12Hours bool
-}
 
 func (f *Formatter) timeLayout() string {
 	if f.use12Hours {
@@ -34,10 +58,12 @@ func (f *Formatter) RecordKeyLayout() string {
 	return defaultRecordKeyLayout
 }
 
-func (f *Formatter) ParseRecordKeyString(recordKey string) (time.Time, error) {
-	return time.Parse(f.RecordKeyLayout(), recordKey)
+// ParseRecordKey parses an input string in the form 2006-01-02-15-04 or
+// 2006-01-02-03-04PM depending on the use12hours setting.
+func (f *Formatter) ParseRecordKey(key string) (time.Time, error) {
+	return time.Parse(f.RecordKeyLayout(), key)
 }
 
-func (f *Formatter) RecordKeyString(record Record) string {
+func (f *Formatter) RecordKey(record *Record) string {
 	return record.Start.Format(f.RecordKeyLayout())
 }

--- a/core/formatter.go
+++ b/core/formatter.go
@@ -27,7 +27,7 @@ const (
 	default12HoursRecordKeyLayout = "2006-01-02-03-04PM"
 )
 
-func (f *Formatter) recordKeyLayout() string {
+func (f *Formatter) RecordKeyLayout() string {
 	if f.use12Hours {
 		return default12HoursRecordKeyLayout
 	}
@@ -35,9 +35,9 @@ func (f *Formatter) recordKeyLayout() string {
 }
 
 func (f *Formatter) ParseRecordKeyString(recordKey string) (time.Time, error) {
-	return time.Parse(f.recordKeyLayout(), recordKey)
+	return time.Parse(f.RecordKeyLayout(), recordKey)
 }
 
 func (f *Formatter) RecordKeyString(record Record) string {
-	return record.Start.Format(f.recordKeyLayout())
+	return record.Start.Format(f.RecordKeyLayout())
 }


### PR DESCRIPTION
With this PR, existing code that checks the `Config.Use12Hours` field and set the date/time layout manually will be replaced with calls to `core.Formatter`.