### PR TITLE
Handle editing of incomplete record

### DIFF
--- a/core/record.go
+++ b/core/record.go
@@ -127,12 +127,18 @@ func (t *Timetrace) EditRecord(recordTime time.Time, plus string, minus string) 
 		if err != nil {
 			return err
 		}
+		if record.End == nil {
+			return errors.New("record is still in progress")
+		}
 		newEnd := record.End.Add(dur)
 		record.End = &newEnd
 	} else {
 		dur, err := time.ParseDuration(minus)
 		if err != nil {
 			return err
+		}
+		if record.End == nil {
+			return errors.New("record is still in progress")
 		}
 		newEnd := record.End.Add(-dur)
 		if newEnd.Before(record.Start) {

--- a/core/record.go
+++ b/core/record.go
@@ -122,32 +122,15 @@ func (t *Timetrace) EditRecord(recordTime time.Time, plus string, minus string) 
 		return err
 	}
 
-	if plus != "" {
-		dur, err := time.ParseDuration(plus)
-		if err != nil {
-			return err
-		}
-		if record.End == nil {
-			return errors.New("record is still in progress")
-		}
-		newEnd := record.End.Add(dur)
-		record.End = &newEnd
-	} else {
-		dur, err := time.ParseDuration(minus)
-		if err != nil {
-			return err
-		}
-		if record.End == nil {
-			return errors.New("record is still in progress")
-		}
-		newEnd := record.End.Add(-dur)
-		if newEnd.Before(record.Start) {
-			return errors.New("new ending time is before start time of record")
-		}
-		record.End = &newEnd
+	err = t.editRecord(record, plus, minus)
+	if err != nil {
+		return err
 	}
 
-	t.SaveRecord(*record, true)
+	err = t.SaveRecord(*record, true)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -246,4 +229,28 @@ func (t *Timetrace) loadRecord(path string) (*Record, error) {
 	}
 
 	return &record, nil
+}
+
+func (t *Timetrace) editRecord(record *Record, plus string, minus string) error {
+	var dur time.Duration
+	var err error
+	if plus != "" {
+		dur, err = time.ParseDuration(plus)
+	} else {
+		dur, err = time.ParseDuration(minus)
+		dur = -dur
+	}
+	if err != nil {
+		return err
+	}
+	if record.End == nil {
+		return errors.New("record is still in progress")
+	}
+	newEnd := record.End.Add(dur)
+	if newEnd.Before(record.Start) {
+		return errors.New("new ending time is before start time of record")
+	}
+	record.End = &newEnd
+
+	return nil
 }

--- a/core/record.go
+++ b/core/record.go
@@ -232,6 +232,11 @@ func (t *Timetrace) loadRecord(path string) (*Record, error) {
 }
 
 func (t *Timetrace) editRecord(record *Record, plus string, minus string) error {
+
+	if record.End == nil {
+		return errors.New("record is still in progress")
+	}
+
 	var dur time.Duration
 	var err error
 	if plus != "" {
@@ -243,9 +248,7 @@ func (t *Timetrace) editRecord(record *Record, plus string, minus string) error 
 	if err != nil {
 		return err
 	}
-	if record.End == nil {
-		return errors.New("record is still in progress")
-	}
+
 	newEnd := record.End.Add(dur)
 	if newEnd.Before(record.Start) {
 		return errors.New("new ending time is before start time of record")


### PR DESCRIPTION
closes #68 

- Throw `record is still in progress` error on trying to edit incomplete record
- Refactor common logic into `editRecord` method