### PR TITLE
Display project modules

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -35,8 +35,8 @@ func listProjectsCommand(t *core.Timetrace) *cobra.Command {
 				out.Err("Failed to list projects: %s", err.Error())
 				return
 			}
-			
-			// remove all modules from the project list 
+
+			// remove all modules from the project list
 			parentProjects := removeModules(allProjects)
 
 			rows := make([][]string, len(parentProjects))

--- a/cli/list.go
+++ b/cli/list.go
@@ -42,7 +42,7 @@ func listProjectsCommand(t *core.Timetrace) *cobra.Command {
 			rows := make([][]string, len(parentProjects))
 
 			for i, project := range parentProjects {
-				allModules, err := t.ListAllModules(project)
+				allModules, err := t.ListProjectModules(project)
 				if err != nil {
 					out.Err("Failed to load project modules: %s", err.Error())
 					return

--- a/core/project.go
+++ b/core/project.go
@@ -45,6 +45,30 @@ func (t *Timetrace) LoadProject(key string) (*Project, error) {
 	return t.loadProject(path)
 }
 
+// ListAllModules loads all modules for a project and returns their keys as a concatenated string
+func (t *Timetrace) ListAllModules(project *Project) (string, error) {
+	allModules, err := t.loadProjectModules(project)
+	if err != nil {
+		return "", err
+	}
+
+	if len(allModules) == 0 {
+		return "-", nil
+	}
+
+	var mList string
+	for i, p := range allModules {
+		// get the name of the module without the prefix
+		mList += strings.Split(p.Key, "@")[0]
+		// append comma if it is not the last element
+		if i+1 != len(allModules) {
+			mList += ","
+		}
+	}
+
+	return mList, nil
+}
+
 // ListProjects loads and returns all stored projects sorted by their filenames.
 // If no projects are found, an empty slice and no error will be returned.
 func (t *Timetrace) ListProjects() ([]*Project, error) {
@@ -151,7 +175,7 @@ func (t *Timetrace) loadProjectModules(project *Project) ([]*Project, error) {
 
 	for _, p := range projects {
 		if p.Parent() == project.Key {
-			modules = append(modules, project)
+			modules = append(modules, p)
 		}
 	}
 

--- a/core/project.go
+++ b/core/project.go
@@ -45,8 +45,8 @@ func (t *Timetrace) LoadProject(key string) (*Project, error) {
 	return t.loadProject(path)
 }
 
-// ListAllModules loads all modules for a project and returns their keys as a concatenated string
-func (t *Timetrace) ListAllModules(project *Project) (string, error) {
+// ListProjectModules loads all modules for a project and returns their keys as a concatenated string
+func (t *Timetrace) ListProjectModules(project *Project) (string, error) {
 	allModules, err := t.loadProjectModules(project)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
closes #60 

I added a new method ListProjectModules that uses loadProjectModules to create a string with all the modules of a project. 
They will be printed out on `timetrace list projects`

But there is a problem with this solution: Modules, that are created for a non-existent parent-project are not listed at all. Therefore, I would propose that we prevent users from creating modules for non-existent projects. 