### PR TITLE
Add latest alias to `edit record` command

### DIFF
--- a/cli/edit.go
+++ b/cli/edit.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"errors"
+	"strings"
+	"time"
 
 	"github.com/dominikbraun/timetrace/core"
 	"github.com/dominikbraun/timetrace/out"
@@ -54,7 +56,7 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 	var options editOptions
 
 	editRecord := &cobra.Command{
-		Use:   "record <KEY>",
+		Use:   "record {<KEY>|latest}",
 		Short: "Edit a record",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -63,10 +65,22 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 
-			recordTime, err := t.Formatter().ParseRecordKey(args[0])
-			if err != nil {
-				out.Err("Failed to parse date argument: %s", err.Error())
-				return
+			var recordTime time.Time
+			var err error
+			// if more aliases are needed, this should be expanded to a switch
+			if strings.ToLower(args[0]) == "latest" {
+				recs, err := t.ListRecords(time.Now())
+				if err != nil {
+					out.Err("Latest works only if the latest record is of today")
+					return
+				}
+				recordTime = recs[0].Start
+			} else {
+				recordTime, err = t.Formatter().ParseRecordKey(args[0])
+				if err != nil {
+					out.Err("Failed to parse date argument: %s", err.Error())
+					return
+				}
 			}
 
 			if options.Minus == "" && options.Plus == "" {

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -69,7 +69,7 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 			var err error
 			// if more aliases are needed, this should be expanded to a switch
 			if strings.ToLower(args[0]) == "latest" {
-				rec, err := t.GetLatestRecord()
+				rec, err := t.LoadLatestRecord()
 				if err != nil {
 					out.Err("Error on loading last record: %s", err.Error())
 					return

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -69,12 +69,12 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 			var err error
 			// if more aliases are needed, this should be expanded to a switch
 			if strings.ToLower(args[0]) == "latest" {
-				recs, err := t.ListRecords(time.Now())
+				rec, err := t.GetLatestRecord()
 				if err != nil {
-					out.Err("Latest works only if the latest record is of today")
+					out.Err("Error on loading last record: %s", err.Error())
 					return
 				}
-				recordTime = recs[0].Start
+				recordTime = rec.Start
 			} else {
 				recordTime, err = t.Formatter().ParseRecordKey(args[0])
 				if err != nil {

--- a/core/record.go
+++ b/core/record.go
@@ -57,7 +57,7 @@ func (t *Timetrace) ListRecords(date time.Time) ([]*Record, error) {
 }
 
 // GetLatestRecord loads and returns the latest record made. If no records
-// are found, an empty slice and no error will be returned.
+// are found, an error will be returned.
 func (t *Timetrace) GetLatestRecord() (*Record, error) {
 	dirs, err := t.fs.RecordDirs()
 	if err != nil {

--- a/core/record.go
+++ b/core/record.go
@@ -56,6 +56,35 @@ func (t *Timetrace) ListRecords(date time.Time) ([]*Record, error) {
 	return records, nil
 }
 
+// GetLatestRecord loads and returns the latest record made. If no records
+// are found, an empty slice and no error will be returned.
+func (t *Timetrace) GetLatestRecord() (*Record, error) {
+	dirs, err := t.fs.RecordDirs()
+	if err != nil {
+		return nil, err
+	}
+
+	latestDir := dirs[len(dirs)-1]
+
+	latestRecs, err := t.fs.RecordFilepaths(latestDir, func(a, b string) bool {
+		timeA, _ := time.Parse("15-04.json", a)
+		timeB, _ := time.Parse("15-04.json", b)
+		return timeA.Before(timeB)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	record, err := t.loadRecord(latestRecs[len(latestRecs)-1])
+
+	if err != nil {
+		return nil, err
+	}
+
+	return record, nil
+}
+
 // SaveRecord persists the given record. Returns ErrRecordAlreadyExists if the
 // record already exists and saving isn't forced.
 func (t *Timetrace) SaveRecord(record Record, force bool) error {

--- a/core/record.go
+++ b/core/record.go
@@ -64,6 +64,10 @@ func (t *Timetrace) GetLatestRecord() (*Record, error) {
 		return nil, err
 	}
 
+	if len(dirs) == 0 {
+		return nil, errors.New("There are currently no records")
+	}
+
 	latestDir := dirs[len(dirs)-1]
 
 	latestRecs, err := t.fs.RecordFilepaths(latestDir, func(a, b string) bool {
@@ -74,6 +78,10 @@ func (t *Timetrace) GetLatestRecord() (*Record, error) {
 
 	if err != nil {
 		return nil, err
+	}
+
+	if len(latestRecs) == 0 {
+		return nil, errors.New("Something went wrong on loading the latest records")
 	}
 
 	record, err := t.loadRecord(latestRecs[len(latestRecs)-1])

--- a/core/record.go
+++ b/core/record.go
@@ -56,43 +56,6 @@ func (t *Timetrace) ListRecords(date time.Time) ([]*Record, error) {
 	return records, nil
 }
 
-// GetLatestRecord loads and returns the latest record made. If no records
-// are found, an error will be returned.
-func (t *Timetrace) GetLatestRecord() (*Record, error) {
-	dirs, err := t.fs.RecordDirs()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(dirs) == 0 {
-		return nil, errors.New("There are currently no records")
-	}
-
-	latestDir := dirs[len(dirs)-1]
-
-	latestRecs, err := t.fs.RecordFilepaths(latestDir, func(a, b string) bool {
-		timeA, _ := time.Parse("15-04.json", a)
-		timeB, _ := time.Parse("15-04.json", b)
-		return timeA.Before(timeB)
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(latestRecs) == 0 {
-		return nil, errors.New("Something went wrong on loading the latest records")
-	}
-
-	record, err := t.loadRecord(latestRecs[len(latestRecs)-1])
-
-	if err != nil {
-		return nil, err
-	}
-
-	return record, nil
-}
-
 // SaveRecord persists the given record. Returns ErrRecordAlreadyExists if the
 // record already exists and saving isn't forced.
 func (t *Timetrace) SaveRecord(record Record, force bool) error {
@@ -206,9 +169,9 @@ func (t *Timetrace) loadAllRecords(date time.Time) ([]*Record, error) {
 	return records, nil
 }
 
-// loadLatestRecord loads the youngest record. This may also be a record from
+// LoadLatestRecord loads the youngest record. This may also be a record from
 // another day. If there is no latest record, nil and no error will be returned.
-func (t *Timetrace) loadLatestRecord() (*Record, error) {
+func (t *Timetrace) LoadLatestRecord() (*Record, error) {
 	latestDirs, err := t.fs.RecordDirs()
 	if err != nil {
 		return nil, err

--- a/core/timetrace.go
+++ b/core/timetrace.go
@@ -52,7 +52,7 @@ func New(config *config.Config, fs Filesystem) *Timetrace {
 //
 // Since parallel work isn't supported, the previous work must be stopped first.
 func (t *Timetrace) Start(projectKey string, isBillable bool) error {
-	latestRecord, err := t.loadLatestRecord()
+	latestRecord, err := t.LoadLatestRecord()
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (t *Timetrace) Status() (*Report, error) {
 		return nil, ErrTrackingNotStarted
 	}
 
-	latestRecord, err := t.loadLatestRecord()
+	latestRecord, err := t.LoadLatestRecord()
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (t *Timetrace) Status() (*Report, error) {
 
 // Stop stops the time tracking and marks the current record as ended.
 func (t *Timetrace) Stop() error {
-	latestRecord, err := t.loadLatestRecord()
+	latestRecord, err := t.LoadLatestRecord()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
closes #71

I implemented the `latest` alias for `edit record` by writing a new method `GetLatestRecord` in record.go. 
Since the fs-methods return sorted slices, it should be ensured that the last element of the slice is also the last created record.
If there are no records created yet, an error is returned.

