### PR TITLE
Add `footer` parameter to `out.Table`

### DIFF
--- a/cli/get.go
+++ b/cli/get.go
@@ -38,7 +38,7 @@ func getProjectCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 
-			out.Table([]string{"Key"}, [][]string{{project.Key}})
+			out.Table([]string{"Key"}, [][]string{{project.Key}}, nil)
 		},
 	}
 
@@ -107,5 +107,5 @@ func showRecord(record *core.Record, formatter *core.Formatter) {
 		},
 	}
 
-	out.Table([]string{"Start", "End", "Project", "Billable"}, rows)
+	out.Table([]string{"Start", "End", "Project", "Billable"}, rows, nil)
 }

--- a/cli/list.go
+++ b/cli/list.go
@@ -45,7 +45,7 @@ func listProjectsCommand(t *core.Timetrace) *cobra.Command {
 				rows[i][1] = project.Key
 			}
 
-			out.Table([]string{"#", "Key"}, rows)
+			out.Table([]string{"#", "Key"}, rows, nil)
 		},
 	}
 
@@ -112,7 +112,7 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 				rows[i][4] = billable
 			}
 
-			out.Table([]string{"#", "Project", "Start", "End", "Billable"}, rows)
+			out.Table([]string{"#", "Project", "Start", "End", "Billable"}, rows, nil)
 		},
 	}
 

--- a/cli/status.go
+++ b/cli/status.go
@@ -42,7 +42,7 @@ func statusCommand(t *core.Timetrace) *cobra.Command {
 					report.FormatTodayTime(),
 				},
 			}
-			out.Table([]string{"Current project", "Worked since start", "Worked today"}, rows)
+			out.Table([]string{"Current project", "Worked since start", "Worked today"}, rows, nil)
 		},
 	}
 

--- a/out/out.go
+++ b/out/out.go
@@ -42,11 +42,16 @@ func Err(format string, a ...interface{}) {
 }
 
 // Table renders a table with the given rows to the standard output.
-func Table(header []string, rows [][]string) {
+func Table(header []string, rows [][]string, footer []string) {
 	paddedHeaders := headersWithPadding(header)
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(paddedHeaders)
 	setHeaderColor(table, paddedHeaders)
+	// If footer array is not empty, then render footer in table.
+	if len(footer) > 0 {
+		paddedFooters := headersWithPadding(footer)
+		table.SetFooter(paddedFooters)
+	}
 	table.AppendBulk(rows)
 	table.Render()
 }


### PR DESCRIPTION
This PR adds a `footer` parameter to `out.Table` which can be used to render footers in tables. Currently, all calls to `out.Table` have an additional `nil` argument where footer is not required. This PR is necessary for upcoming one for #58.
