### PR TITLE
added method to check if parent project exists for module

### DIFF
--- a/core/project.go
+++ b/core/project.go
@@ -71,7 +71,7 @@ func (t *Timetrace) ListProjects() ([]*Project, error) {
 // the project already exists and saving isn't forced.
 func (t *Timetrace) SaveProject(project Project, force bool) error {
 	if project.IsModule() {
-		err := t.parentExists(project)
+		err := t.assertParent(project)
 		if err != nil {
 			return err
 		}
@@ -178,21 +178,17 @@ func (t *Timetrace) editorFromEnvironment() string {
 	return defaultEditor
 }
 
-func (t *Timetrace) parentExists(project Project) error {
+func (t *Timetrace) assertParent(project Project) error {
 	allP, err := t.ListProjects()
 	if err != nil {
 		return err
 	}
 
-	found := false
 	for _, p := range allP {
 		if p.Key == project.Parent() {
-			found = true
-			break
+			return nil
 		}
 	}
-	if !found {
-		return ErrParentlessModule
-	}
-	return nil
+
+	return ErrParentlessModule
 }

--- a/core/project.go
+++ b/core/project.go
@@ -70,9 +70,11 @@ func (t *Timetrace) ListProjects() ([]*Project, error) {
 // SaveProject persists the given project. Returns ErrProjectAlreadyExists if
 // the project already exists and saving isn't forced.
 func (t *Timetrace) SaveProject(project Project, force bool) error {
-	err := t.parentExists(project)
-	if err != nil {
-		return err
+	if project.IsModule() {
+		err := t.parentExists(project)
+		if err != nil {
+			return err
+		}
 	}
 
 	path := t.fs.ProjectFilepath(project.Key)
@@ -177,22 +179,20 @@ func (t *Timetrace) editorFromEnvironment() string {
 }
 
 func (t *Timetrace) parentExists(project Project) error {
-	if project.IsModule() {
-		allP, err := t.ListProjects()
-		if err != nil {
-			return err
-		}
+	allP, err := t.ListProjects()
+	if err != nil {
+		return err
+	}
 
-		found := false
-		for _, p := range allP {
-			if p.Key == project.Parent() {
-				found = true
-				break
-			}
+	found := false
+	for _, p := range allP {
+		if p.Key == project.Parent() {
+			found = true
+			break
 		}
-		if !found {
-			return ErrParentlessModule
-		}
+	}
+	if !found {
+		return ErrParentlessModule
 	}
 	return nil
 }


### PR DESCRIPTION
closes #72 

i added a method to check if the parent of a module exists before creating it. 
the create-command now returns an error if it does not exist.