### PR TITLE
Plugin support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ target
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+plugins/*
+!plugins/example

--- a/cli/root.go
+++ b/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/dominikbraun/timetrace/core"
+	"github.com/dominikbraun/timetrace/plugin"
 
 	"github.com/spf13/cobra"
 )
@@ -11,7 +12,7 @@ const (
 	defaultBool   = "no"
 )
 
-func RootCommand(t *core.Timetrace, version string) *cobra.Command {
+func RootCommand(t *core.Timetrace, version string, plugins *plugin.Plugins) *cobra.Command {
 	root := &cobra.Command{
 		Use:           "timetrace",
 		Short:         "timetrace is a simple CLI for tracking your working time.",
@@ -35,6 +36,8 @@ func RootCommand(t *core.Timetrace, version string) *cobra.Command {
 	root.AddCommand(statusCommand(t))
 	root.AddCommand(stopCommand(t))
 	root.AddCommand(versionCommand(version))
+
+	plugins.AddToCobra(root)
 
 	return root
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,9 +6,10 @@ import (
 )
 
 type Config struct {
-	Store      string `json:"store"`
-	Use12Hours bool   `json:"use12hours"`
-	Editor     string `json:"editor"`
+	Store        string `json:"store"`
+	Use12Hours   bool   `json:"use12hours"`
+	Editor       string `json:"editor"`
+	PluginFolder string `json:"pluginFolder"`
 }
 
 var cached *Config

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dominikbraun/timetrace
 go 1.15
 
 require (
+	github.com/aligator/goplug v0.0.3
 	github.com/enescakir/emoji v1.0.0
 	github.com/fatih/color v1.10.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,12 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/aligator/goplug v0.0.1 h1:8KhtKgZmPfFlQmwy2DWp6Pxwtak4YKdEdp6MPx8vjPM=
+github.com/aligator/goplug v0.0.1/go.mod h1:txONK1ojkFOj9A/PhTN/FvCqZJg0T++VOz4V/xiv5yc=
+github.com/aligator/goplug v0.0.2 h1:dZO/vkeyv9FqQ1ch467mSd+hpiy0NKLPs0pIYN4Y27w=
+github.com/aligator/goplug v0.0.2/go.mod h1:txONK1ojkFOj9A/PhTN/FvCqZJg0T++VOz4V/xiv5yc=
+github.com/aligator/goplug v0.0.3 h1:OuIekJOQysEF73LMLPrwycEr38MWm+hfYCVJd/wpjSI=
+github.com/aligator/goplug v0.0.3/go.mod h1:txONK1ojkFOj9A/PhTN/FvCqZJg0T++VOz4V/xiv5yc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
+//go:generate go build -o ./plugins ./plugins/example/hello
 package main
 
 import (
+	"github.com/dominikbraun/timetrace/plugin"
 	"os"
 
 	"github.com/dominikbraun/timetrace/cli"
@@ -18,10 +20,14 @@ func main() {
 		out.Warn("%s", err.Error())
 	}
 
+	plugins := &plugin.Plugins{}
+	plugins.Init(c)
+	defer plugins.Close()
+
 	filesystem := fs.New(c)
 	timetrace := core.New(c, filesystem)
 
-	if err := cli.RootCommand(timetrace, version).Execute(); err != nil {
+	if err := cli.RootCommand(timetrace, version, plugins).Execute(); err != nil {
 		out.Err("%s", err.Error())
 		os.Exit(1)
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,37 @@
+package plugin
+
+import "github.com/aligator/goplug"
+
+// TimetracePlugin provides the methods, which can be used by plugins.
+type TimetracePlugin struct {
+	goplug.Plugin
+}
+
+func New(ID string) TimetracePlugin {
+	return TimetracePlugin{
+		Plugin: goplug.Plugin{
+			ID: ID,
+		},
+	}
+}
+
+func (p *TimetracePlugin) OnCommand(listener func(cmd OnCommand) error) {
+	p.RegisterCommand("command", func() interface{} {
+		return &OnCommand{}
+	}, func(message interface{}) error {
+		data := message.(*OnCommand)
+		if p.ID == data.Cmd.PluginID {
+			return listener(*data)
+		}
+
+		return nil
+	})
+}
+
+func (p TimetracePlugin) RegisterCobraCommand(cmd RegisterCobraCommand) error {
+	return p.Send("registerCobraCommand", cmd)
+}
+
+func (p TimetracePlugin) Print(message string) error {
+	return p.Send("print", message)
+}

--- a/plugin/setup.go
+++ b/plugin/setup.go
@@ -1,0 +1,91 @@
+package plugin
+
+import (
+	"fmt"
+	"github.com/aligator/goplug"
+	"github.com/dominikbraun/timetrace/config"
+	"github.com/spf13/cobra"
+)
+
+type RegisterCobraCommand struct {
+	// ToDo: PluginID will become private or removed completely
+	//       when commands get only sent to one specific plugin.
+	PluginID string `json:"pluginId"`
+	Use      string `json:"use"`
+	Short    string `json:"short"`
+	Long     string `json:"long"`
+	Example  string `json:"example"`
+}
+
+type OnCommand struct {
+	Cmd  RegisterCobraCommand `json:"cmd"`
+	Args []string             `json:"args"`
+}
+
+type Plugins struct {
+	GoPlug   *goplug.GoPlug
+	commands []RegisterCobraCommand
+}
+
+func (p *Plugins) Init(c *config.Config) error {
+	if c.PluginFolder == "" {
+		c.PluginFolder = "plugins"
+	}
+
+	p.GoPlug = &goplug.GoPlug{
+		PluginFolder: c.PluginFolder,
+	}
+
+	// Just a simple print command.
+	p.GoPlug.RegisterOnCommand("print", func() interface{} {
+		var s string
+		return &s
+	}, func(info goplug.PluginInfo, message interface{}) error {
+		text := message.(*string)
+		fmt.Print(*text)
+		return nil
+	})
+
+	p.GoPlug.RegisterOnCommand("registerCobraCommand", func() interface{} {
+		return &RegisterCobraCommand{}
+	}, func(info goplug.PluginInfo, message interface{}) error {
+		cobraData := message.(*RegisterCobraCommand)
+		cobraData.PluginID = info.ID
+
+		p.commands = append(p.commands, *cobraData)
+		return nil
+	})
+
+	err := p.GoPlug.Init()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Plugins) AddToCobra(root *cobra.Command) error {
+	for _, pluginCmd := range p.commands {
+		root.AddCommand(&cobra.Command{
+			Use:     pluginCmd.Use,
+			Short:   pluginCmd.Short,
+			Long:    pluginCmd.Long,
+			Example: pluginCmd.Example,
+			Run: func(cmd *cobra.Command, args []string) {
+				// ToDo: for now it is sent to all plugins.
+				//       This has to be changed, so only the plugin which
+				//       registered the command receives it.
+				p.GoPlug.Send("command", OnCommand{
+					Cmd:  pluginCmd,
+					Args: args,
+				})
+			},
+		})
+	}
+
+	return nil
+}
+
+func (p *Plugins) Close() error {
+	return p.GoPlug.Close()
+}

--- a/plugins/example/hello/main.go
+++ b/plugins/example/hello/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"github.com/dominikbraun/timetrace/plugin"
+	"strings"
+)
+
+func main() {
+	p := plugin.New("HelloWorld")
+	err := p.Register()
+	if err != nil {
+		panic(err)
+	}
+
+	logger := p.Logger()
+	logger.Println("Initializing")
+
+	p.RegisterCobraCommand(plugin.RegisterCobraCommand{
+		Use:     "hello",
+		Short:   "prints Hello World and all arguments",
+		Example: "hello",
+	})
+
+	p.OnCommand(func(cmd plugin.OnCommand) error {
+		if cmd.Cmd.Use == "hello" {
+			return p.Print("Hello World" + strings.Join(cmd.Args, ", "))
+		}
+
+		return nil
+	})
+
+	p.OnAllInitialized(func() error {
+		return nil
+	})
+
+	err = p.Run()
+	if err != nil {
+		logger.Println(err)
+	}
+}


### PR DESCRIPTION
As discussed in https://github.com/dominikbraun/timetrace/issues/91 we may need plugins.

This is a first draft, which uses the GoPlug lib, which I created specifically for timetrace.
Both, this PR and GoPlug are in a very experimental and untested stage.
So feel free to leave suggestions or even other ideas to implement plugins.

Currently it is possible to add custom commands to timetrace and to print text to stdout.
Argument parsing has to be done in the plugin separately. (It should be possible to just use another cobra instance for that??)
(however don't know yet how to pass the help-output (e.g. timetrace help hello) to the plugin.

This should be enough to implement https://github.com/dominikbraun/timetrace/issues/91 as plugin.

# Example
I added a basic example which adds a new timetrace subcommand `timetrace hello`  
To run it, first build the plugin by running
```bash
go generate
```
Then just run 
```
go run . hello some other arguments...
```
It will print out "Hello World" and the other passed arguments.
The hello command will even be visible in the timetrace help.


As GoPlug works through stdin / stdout, it should be possible to write plugins in any language. (haven't tried that yet)