### PR TITLE
[Patch] Remove seconds from Time Formatter

### DIFF
--- a/core/formatter.go
+++ b/core/formatter.go
@@ -88,18 +88,11 @@ func (f *Formatter) FormatBreakTime(report *Report) string {
 }
 
 // formatDuration formats the passed duration into a string.
-// The format will be "8h 24min". If the duration is less then 60 secods
-// the format will be "0h 0min 12sec".
+// The format will be "8h 24min".
+// seconds information is ignored.
 func (f *Formatter) formatDuration(duration time.Duration) string {
 
 	hours := int64(duration.Hours()) % 60
 	minutes := int64(duration.Minutes()) % 60
-	secods := int64(duration.Seconds()) % 60
-
-	// as by convention if the duarion is < then 60 secods
-	// return "0h 0min Xsec"
-	if hours == 0 && minutes == 0 {
-		return fmt.Sprintf("0h 0min %dsec", secods)
-	}
 	return fmt.Sprintf("%dh %dmin", hours, minutes)
 }


### PR DESCRIPTION
In the time formatter package, if `hours` and `minutes` are 0 then `seconds` will be considered. As seconds is not handled in users perspective, `seconds` need not be considered. 