### PR TITLE
Add basic format option

### DIFF
--- a/cli/status.go
+++ b/cli/status.go
@@ -59,9 +59,10 @@ func statusCommand(t *core.Timetrace) *cobra.Command {
 				format = strings.ReplaceAll(format, "{breakTime}", t.Formatter().FormatBreakTime(report))
 				format = strings.ReplaceAll(format, `\n`, "\n")
 				fmt.Printf(format)
-			} else {
-				out.Table([]string{"Current project", "Worked since start", "Worked today", "Breaks"}, rows, nil)
+				return
 			}
+			
+			out.Table([]string{"Current project", "Worked since start", "Worked today", "Breaks"}, rows, nil)
 		},
 	}
 

--- a/cli/status.go
+++ b/cli/status.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/dominikbraun/timetrace/core"
 	"github.com/dominikbraun/timetrace/out"
@@ -10,6 +12,8 @@ import (
 )
 
 func statusCommand(t *core.Timetrace) *cobra.Command {
+	var format string
+
 	status := &cobra.Command{
 		Use:   "status",
 		Short: "Display the current tracking status",
@@ -48,9 +52,20 @@ func statusCommand(t *core.Timetrace) *cobra.Command {
 					t.Formatter().FormatBreakTime(report),
 				},
 			}
-			out.Table([]string{"Current project", "Worked since start", "Worked today", "Breaks"}, rows, nil)
+			if format != "" {
+				format = strings.ReplaceAll(format, "{project}", project)
+				format = strings.ReplaceAll(format, "{trackedTimeCurrent}", trackedTimeCurrent)
+				format = strings.ReplaceAll(format, "{todayTime}", t.Formatter().FormatTodayTime(report))
+				format = strings.ReplaceAll(format, "{breakTime}", t.Formatter().FormatBreakTime(report))
+				format = strings.ReplaceAll(format, `\n`, "\n")
+				fmt.Printf(format)
+			} else {
+				out.Table([]string{"Current project", "Worked since start", "Worked today", "Breaks"}, rows, nil)
+			}
 		},
 	}
+
+	status.Flags().StringVarP(&format, "format", "f", "", "Format string, availiable:\n{project}, {trackedTimeCurrent}, {todayTime}, {breakTime}")
 
 	return status
 }


### PR DESCRIPTION
Initial very basic implementation for #109 

I didn't write any test and actually used `fmt.Printf`  should I create an `out.Printf` or something like this?

Please any suggestions are welcome, I am not really a golang dev =P

To have better options to replace and format, we would need to add more information to the status command.
