### PR TITLE
enable flags on start command

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -17,7 +17,6 @@ func startCommand(t *core.Timetrace) *cobra.Command {
 	start := &cobra.Command{
 		Use:   "start <PROJECT KEY>",
 		Short: "Start tracking time",
-		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			projectKey := args[0]
 


### PR DESCRIPTION
closes #117

I just deleted the "ExactArgs" line. Not it works fine for me :)