### PR TITLE
Rename formatting variables for `--format` flag

### DIFF
--- a/cli/status.go
+++ b/cli/status.go
@@ -55,8 +55,8 @@ func statusCommand(t *core.Timetrace) *cobra.Command {
 			if format != "" {
 				format = strings.ReplaceAll(format, "{project}", project)
 				format = strings.ReplaceAll(format, "{trackedTimeCurrent}", trackedTimeCurrent)
-				format = strings.ReplaceAll(format, "{todayTime}", t.Formatter().FormatTodayTime(report))
-				format = strings.ReplaceAll(format, "{breakTime}", t.Formatter().FormatBreakTime(report))
+				format = strings.ReplaceAll(format, "{trackedTimeToday}", t.Formatter().FormatTodayTime(report))
+				format = strings.ReplaceAll(format, "{breakTimeToday}", t.Formatter().FormatBreakTime(report))
 				format = strings.ReplaceAll(format, `\n`, "\n")
 				fmt.Printf(format)
 				return

--- a/cli/status.go
+++ b/cli/status.go
@@ -66,7 +66,7 @@ func statusCommand(t *core.Timetrace) *cobra.Command {
 		},
 	}
 
-	status.Flags().StringVarP(&format, "format", "f", "", "Format string, availiable:\n{project}, {trackedTimeCurrent}, {todayTime}, {breakTime}")
+	status.Flags().StringVarP(&format, "format", "f", "", "Format string, availiable:\n{project}, {trackedTimeCurrent}, {trackedTimeToday}, {breakTimeToday}")
 
 	return status
 }


### PR DESCRIPTION
I noticed that two formatting variables had a slighty different name than the struct fields. I thought it would be nice if those names were the same:

https://github.com/dominikbraun/timetrace/blob/b4b7c153e92cd869ac34e92fedc0d6a16460862c/core/timetrace.go#L18-L22

This PR fixes that.