### PR TITLE
Implement `--output` flag for `timetrace status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ![CLI screenshot 64x16](timetrace.png)
 
-:fire: **New:** [Display the tracking status as JSON or in your own format](#print-the-tracking-status)
+:fire: **New:** [Display the tracking status as JSON or in your own format](#print-the-tracking-status)  
 :fire: **New:** [Reverting `edit` and `delete` commands is now possible](#edit-a-record)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 ![CLI screenshot 64x16](timetrace.png)
 
+:fire: **New:** [Display the tracking status as JSON or in your own format](#print-the-tracking-status)
 :fire: **New:** [Reverting `edit` and `delete` commands is now possible](#edit-a-record)
 
 ## Installation
@@ -112,9 +113,112 @@ when = "timetrace status"
 shell = "sh"
 ```
 
-You can find a list of available formatting variables in the [`status` reference](#print-current-status).
+You can find a list of available formatting variables in the [`status` reference](#print-the-tracking-status).
 
 ## Command reference
+
+### Start tracking
+
+**Syntax:**
+
+```
+timetrace start <PROJECT KEY>
+```
+
+**Arguments:**
+
+|Argument|Description|
+|-|-|
+|`PROJECT KEY`|The key of the project.|
+
+**Flags:**
+
+|Flag|Short|Description|
+|-|-|-|
+|`--billable`|`-b`|Mark the record as billable.|
+
+**Example:**
+
+Start working on a project called `make-coffee` and mark it as billable:
+
+```
+timetrace start --billable make-coffee
+```
+
+### Print the tracking status
+
+**Syntax:**
+
+```
+timetrace status
+```
+
+**Flags:**
+
+|Flag|Short|Description|
+|-|-|-|
+|`--format`|`-f`|Display the status in a custom format (see below).|
+|`--output`|`-o`|Display the status in a specific output. Valid values: `json`|
+
+**Formatting variables:**
+
+The names of the formatting variables are the same as the JSON keys printed by `--output json`.
+
+|Variable|Description|
+|-|-|
+|`{project}`|The key of the current project.|
+|`{trackedTimeCurrent}`|The time tracked for the current record.|
+|`{trackedTimeToday}`|The time tracked today.|
+|`{breakTimeToday}`|The break time since the first record.|
+
+**Example:**
+
+Print the current tracking status:
+
+```
+timetrace status
++-------------------+----------------------+----------------+
+|  CURRENT PROJECT  |  WORKED SINCE START  |  WORKED TODAY  |
++-------------------+----------------------+----------------+
+| make-coffee       | 1h 15min             | 4h 30min       |
++-------------------+----------------------+----------------+
+```
+
+Print the current project and the total working time as a custom string. Given the example above, the output will be
+`Current project: make-coffee - Worked today: 3h 30min`.
+
+```
+timetrace status --format "Current project: {project} - Worked today: {trackedTimeToday}"
+```
+
+Print the status as JSON:
+
+```
+timetrace status -o json
+{
+        "project": "web-store",
+        "trackedTimeCurrent": "1h 45min",
+        "trackedTimeToday": "7h 30min",
+        "breakTimeToday": "0h 30min"
+}
+
+```
+
+### Stop tracking
+
+**Syntax:**
+
+```
+timetrace stop
+```
+
+**Example:**
+
+Stop working on your current project:
+
+```
+timetrace stop
+```
 
 ### Create a project
 
@@ -399,94 +503,6 @@ timetrace delete record 2021-05-01-15-00
 
 ```
 timetrace delete record 2021-05-01-15-00 --revert
-```
-
-### Start tracking
-
-**Syntax:**
-
-```
-timetrace start <PROJECT KEY>
-```
-
-**Arguments:**
-
-|Argument|Description|
-|-|-|
-|`PROJECT KEY`|The key of the project.|
-
-**Flags:**
-
-|Flag|Short|Description|
-|-|-|-|
-|`--billable`|`-b`|Mark the record as billable.|
-
-**Example:**
-
-Start working on a project called `make-coffee` and mark it as billable:
-
-```
-timetrace start --billable make-coffee
-```
-
-### Print current status
-
-**Syntax:**
-
-```
-timetrace status
-```
-
-**Flags:**
-
-|Flag|Short|Description|
-|-|-|-|
-|`--format`|`-f`|Display the status in a custom format (see below).|
-
-**Formatting variables:**
-
-|Variable|Description|
-|-|-|
-|`{project}`|The key of the current project.|
-|`{trackedTimeCurrent}`|The time tracked for the current record.|
-|`{trackedTimeToday}`|The time tracked today.|
-|`{breakTimeToday}`|The break time since the first record.|
-
-**Example:**
-
-Print the current tracking status:
-
-```
-timetrace status
-+-------------------+----------------------+----------------+
-|  CURRENT PROJECT  |  WORKED SINCE START  |  WORKED TODAY  |
-+-------------------+----------------------+----------------+
-| make-coffee       | 1h 15min             | 4h 30min       |
-+-------------------+----------------------+----------------+
-```
-
-Print the current project and the total working time as a custom string:
-
-```
-timetrace status --format "Current project: {project} - Worked today: {trackedTimeToday}"
-```
-
-Given the example above, the output will be `Current project: make-coffee - Worked today: 3h 30min`.
-
-### Stop tracking
-
-**Syntax:**
-
-```
-timetrace stop
-```
-
-**Example:**
-
-Stop working on your current project:
-
-```
-timetrace stop
 ```
 
 ### Print version information


### PR DESCRIPTION
Resolves #128.

This PR also introduces a `statusReport` type that stores all printed strings. It is initialized with the relevant values, and the individual formatting and output options just use that instance for printing the status.