### PR TITLE
Simplify record keys

### DIFF
--- a/cli/edit.go
+++ b/cli/edit.go
@@ -83,38 +83,11 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 
-			var recordTime time.Time
-			var err error
-			// if more aliases are needed, this should be expanded to a switch
-			if strings.ToLower(args[0]) == "latest" {
-				rec, err := t.LoadLatestRecord()
-				if err != nil {
-					out.Err("Error on loading last record: %s", err.Error())
-					return
-				}
-				recordTime = rec.Start
-			} else if strings.Contains(args[0], "@") {
-				id, err := strconv.Atoi(args[0][1:])
-				if err != nil {
-					out.Err("Error on parsing ID: %s", err.Error())
-					return
-				}
-				rec, err := t.LoadRecordByID(id)
-				if err != nil {
-					out.Err("Error on loading last record: %s", err.Error())
-					return
-				}
-				if rec == nil {
-					out.Err("No record of given ID started today.")
-					return
-				}
-				recordTime = rec.Start
-			} else {
-				recordTime, err = t.Formatter().ParseRecordKey(args[0])
-				if err != nil {
-					out.Err("Failed to parse date argument: %s", err.Error())
-					return
-				}
+			recordTime, err := getRecordTimeFromArg(t, args[0])
+
+			if err != nil {
+				out.Err(err.Error())
+				return
 			}
 
 			if options.Revert {
@@ -153,4 +126,42 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 	editRecord.PersistentFlags().BoolVarP(&options.Revert, "revert", "r", false, "Restores the record to it's state prior to the last 'edit' command.")
 
 	return editRecord
+}
+
+func getRecordTimeFromArg(t *core.Timetrace, arg string) (time.Time, error) {
+	var recordTime time.Time
+	var err error
+	// if more aliases are needed, this should be expanded to a switch
+	if strings.ToLower(arg) == "latest" {
+		rec, err := t.LoadLatestRecord()
+		if err != nil {
+			err = errors.New("error on loading last record: " + err.Error())
+			return recordTime, err
+		}
+		recordTime = rec.Start
+	} else if strings.Contains(arg, "@") {
+		id, err := strconv.Atoi(arg[1:])
+		if err != nil {
+			err = errors.New("error on parsing ID: " + err.Error())
+			return recordTime, err
+		}
+		rec, err := t.LoadRecordByID(id)
+		if err != nil {
+			err = errors.New("Error on loading last record: " + err.Error())
+			return recordTime, err
+		}
+		if rec == nil {
+			err = errors.New("no record of given ID started today")
+			return recordTime, err
+		}
+		recordTime = rec.Start
+	} else {
+		recordTime, err = t.Formatter().ParseRecordKey(arg)
+		if err != nil {
+			err = errors.New("Failed to parse date argument: " + err.Error())
+			return recordTime, err
+		}
+	}
+
+	return recordTime, err
 }

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -74,7 +74,7 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 	var options editOptions
 
 	editRecord := &cobra.Command{
-		Use:   "record {<KEY>|latest|*ID}",
+		Use:   "record {<KEY>|latest|@ID}",
 		Short: "Edit a record",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -93,7 +93,7 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 					return
 				}
 				recordTime = rec.Start
-			} else if strings.Contains(args[0], "*") {
+			} else if strings.Contains(args[0], "@") {
 				id, err := strconv.Atoi(args[0][1:])
 				if err != nil {
 					out.Err("Error on parsing ID: %s", err.Error())

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"time"
 
@@ -73,7 +74,7 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 	var options editOptions
 
 	editRecord := &cobra.Command{
-		Use:   "record {<KEY>|latest}",
+		Use:   "record {<KEY>|latest|*ID}",
 		Short: "Edit a record",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -89,6 +90,22 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				rec, err := t.LoadLatestRecord()
 				if err != nil {
 					out.Err("Error on loading last record: %s", err.Error())
+					return
+				}
+				recordTime = rec.Start
+			} else if strings.Contains(args[0], "*") {
+				id, err := strconv.Atoi(args[0][1:])
+				if err != nil {
+					out.Err("Error on parsing ID: %s", err.Error())
+					return
+				}
+				rec, err := t.LoadRecordByID(id)
+				if err != nil {
+					out.Err("Error on loading last record: %s", err.Error())
+					return
+				}
+				if rec == nil {
+					out.Err("No record of given ID started today.")
 					return
 				}
 				recordTime = rec.Start

--- a/cli/list.go
+++ b/cli/list.go
@@ -108,7 +108,7 @@ func listRecordsCommand(t *core.Timetrace) *cobra.Command {
 				}
 
 				rows[i] = make([]string, 6)
-				rows[i][0] = strconv.Itoa(i + 1)
+				rows[i][0] = strconv.Itoa(len(records) - i)
 				rows[i][1] = t.Formatter().RecordKey(record)
 				rows[i][2] = record.Project.Key
 				rows[i][3] = t.Formatter().TimeString(record.Start)

--- a/core/record.go
+++ b/core/record.go
@@ -239,6 +239,22 @@ func (t *Timetrace) loadAllRecordsSortedAscending(date time.Time) ([]*Record, er
 	return records, nil
 }
 
+// LoadRecordByID loads a record of the current day by the ID
+// provided in list records (starting with the oldest as #1)
+func (t *Timetrace) LoadRecordByID(ID int) (*Record, error) {
+	recs, err := t.loadAllRecordsSortedAscending(time.Now())
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(recs) < ID || ID == 0 {
+		return nil, nil
+	}
+
+	return recs[ID-1], nil
+}
+
 // LoadLatestRecord loads the youngest record. This may also be a record from
 // another day. If there is no latest record, nil and no error will be returned.
 func (t *Timetrace) LoadLatestRecord() (*Record, error) {


### PR DESCRIPTION
closes #116

I implemented the features discussed in #116, but I needed to change the "marker" of the ID from `#` to `*`. Otherwise, the argument seems to be ignored. I don't know if it's my terminal or the go library or something else, but the `arg[0]` is empty when the input starts with a `#`. 
This begs two questions: Are you okay with the `*` as a marker, or would you prefer something else? And should we change the header of the list record command accordingly, to avoid confusion?