### PR TITLE
#81 Rename project file

### DIFF
--- a/cli/delete.go
+++ b/cli/delete.go
@@ -114,7 +114,7 @@ func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
 				}
 			}
 
-			if err := t.BackupRecord(start); err != nil {
+			if err := t.BackupRecord(*record); err != nil {
 				out.Err("Failed to backup record before deletion: %s", err.Error())
 				return
 			}

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -84,9 +84,10 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 
 			var recordTime time.Time
 			var err error
+			var rec *core.Record
 			// if more aliases are needed, this should be expanded to a switch
 			if strings.ToLower(args[0]) == "latest" {
-				rec, err := t.LoadLatestRecord()
+				rec, err = t.LoadLatestRecord()
 				if err != nil {
 					out.Err("Error on loading last record: %s", err.Error())
 					return
@@ -96,6 +97,10 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				recordTime, err = t.Formatter().ParseRecordKey(args[0])
 				if err != nil {
 					out.Err("Failed to parse date argument: %s", err.Error())
+					return
+				}
+				rec, err = t.LoadRecord(recordTime)
+				if err != nil {
 					return
 				}
 			}
@@ -109,7 +114,7 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 
-			if err := t.BackupRecord(recordTime); err != nil {
+			if err := t.BackupRecord(*rec); err != nil {
 				out.Err("Failed to backup record before edit: %s", err.Error())
 				return
 			}

--- a/core/project.go
+++ b/core/project.go
@@ -226,6 +226,8 @@ func (t *Timetrace) EditProject(projectKey string) error {
 	// need to rename backup so that it plays well with
 	// new filenames
 	return os.Rename(backupPath, newBackupPath)
+
+	// at this point, loop through records -> {date folders} -> *.json / .json.bak with old project key and rename
 }
 
 // DeleteProject removes the given project. Returns ErrProjectNotFound if the

--- a/core/project.go
+++ b/core/project.go
@@ -183,6 +183,10 @@ func (t *Timetrace) RevertProject(projectKey string) error {
 	if err != nil {
 		return err
 	}
+	err = t.updateProjectOnRecords(projectKey, project)
+	if err != nil {
+		return err
+	}
 
 	_, err = file.Write(bytes)
 

--- a/core/record.go
+++ b/core/record.go
@@ -93,14 +93,9 @@ func (t *Timetrace) SaveRecord(record Record, force bool) error {
 }
 
 // BackupRecord creates a backup of the given record file
-func (t *Timetrace) BackupRecord(recordKey time.Time) error {
-	path := t.fs.RecordFilepath(recordKey)
-	record, err := t.loadRecord(path)
-	if err != nil {
-		return err
-	}
+func (t *Timetrace) BackupRecord(record Record) error {
 	// create a new .bak filepath from the record struct
-	backupPath := t.fs.RecordBackupFilepath(recordKey)
+	backupPath := t.fs.RecordBackupFilepath(record.Start)
 
 	backupFile, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {

--- a/core/record.go
+++ b/core/record.go
@@ -367,3 +367,23 @@ func (t *Timetrace) editRecord(record *Record, plus string, minus string) error 
 
 	return nil
 }
+
+// getAllRecordPaths returns all current and backup record filepaths
+func (t *Timetrace) getAllRecordPaths() ([]string, error) {
+	recordDirs, err := t.fs.RecordDirs()
+	if err != nil {
+		return nil, err
+	}
+
+	allRecordPaths := []string{}
+	for _, recordDir := range recordDirs {
+		paths, err := t.fs.RecordFilepathsUnfiltered(recordDir, func(_, _ string) bool {
+			return true
+		})
+		if err != nil {
+			return nil, err
+		}
+		allRecordPaths = append(allRecordPaths, paths...)
+	}
+	return allRecordPaths, nil
+}

--- a/core/timetrace.go
+++ b/core/timetrace.go
@@ -30,6 +30,7 @@ type Filesystem interface {
 	RecordFilepath(start time.Time) string
 	RecordBackupFilepath(start time.Time) string
 	RecordFilepaths(dir string, less func(a, b string) bool) ([]string, error)
+	RecordFilepathsUnfiltered(dir string, less func(a, b string) bool) ([]string, error)
 	RecordDirs() ([]string, error)
 	ReportDir() string
 	RecordDirFromDate(date time.Time) string

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -144,6 +144,30 @@ func (fs *Fs) RecordFilepaths(dir string, less func(a, b string) bool) ([]string
 	return filepaths, nil
 }
 
+// This function returns all current and backup record filepaths
+func (fs *Fs) RecordFilepathsUnfiltered(dir string, less func(a, b string) bool) ([]string, error) {
+	items, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	filepaths := make([]string, 0)
+
+	for _, item := range items {
+		if item.IsDir() {
+			continue
+		}
+		itemName := item.Name()
+		filepaths = append(filepaths, filepath.Join(dir, itemName))
+	}
+
+	sort.Slice(filepaths, func(i, j int) bool {
+		return less(filepaths[i], filepaths[j])
+	})
+
+	return filepaths, nil
+}
+
 // RecordDirs returns all record directories sorted alphabetically. This can be
 // used to determine the latest record directory and obtain the latest record
 // within that directory using RecordFilepaths.

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -1,0 +1,29 @@
+package fs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dominikbraun/timetrace/config"
+	"github.com/dominikbraun/timetrace/out"
+)
+
+func TestRecordDirs(t *testing.T) {
+	// test output of function
+	c, err := config.FromFile()
+	if err != nil {
+		out.Warn("%s", err.Error())
+	}
+
+	filesystem := New(c)
+	recordDirs, err := filesystem.RecordDirs()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if len(recordDirs) != 2 {
+		t.Fatalf("Length error: expected %v, got %v", len(recordDirs), 2)
+	} else {
+		fmt.Printf("%v\n", recordDirs)
+	}
+}


### PR DESCRIPTION
This PR resolves #81 .

Since the `revert` command relied on the key to get the right backup, I had to make some changes to that logic as well. I decided to always ensure the backup filename matches the current file, which meant when a project filename is changed, so is the backup file.

I also had to make a change to the `BackupRecord` so that it takes a Record type instead of a string as an argument. This change will effect how the `revert` works with the records as well, so my other PR that resolves #89 is effected by this change.