### PR TITLE
#89 Rename record file

### DIFF
--- a/cli/delete.go
+++ b/cli/delete.go
@@ -114,7 +114,7 @@ func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
 				}
 			}
 
-			if err := t.BackupRecord(start); err != nil {
+			if err := t.BackupRecord(*record); err != nil {
 				out.Err("Failed to backup record before deletion: %s", err.Error())
 				return
 			}

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -84,9 +84,10 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 
 			var recordTime time.Time
 			var err error
+			var rec *core.Record
 			// if more aliases are needed, this should be expanded to a switch
 			if strings.ToLower(args[0]) == "latest" {
-				rec, err := t.LoadLatestRecord()
+				rec, err = t.LoadLatestRecord()
 				if err != nil {
 					out.Err("Error on loading last record: %s", err.Error())
 					return
@@ -96,6 +97,10 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				recordTime, err = t.Formatter().ParseRecordKey(args[0])
 				if err != nil {
 					out.Err("Failed to parse date argument: %s", err.Error())
+					return
+				}
+				rec, err = t.LoadRecord(recordTime)
+				if err != nil {
 					return
 				}
 			}
@@ -109,7 +114,7 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 
-			if err := t.BackupRecord(recordTime); err != nil {
+			if err := t.BackupRecord(*rec); err != nil {
 				out.Err("Failed to backup record before edit: %s", err.Error())
 				return
 			}

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -120,6 +121,11 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 			}
 
 			if options.Minus == "" && options.Plus == "" {
+				fmt.Printf("Warning: Directly editing the record can lead to undefined behavior.\nIf you change the start time of the record, the underlying file will be renamed automatically. Make sure it doesn't collide with other records. If you want to change the end time, use --minus or --plus instead.\nContinue? ")
+				if !askForConfirmation() {
+					out.Info("Editting record aborted.")
+					return
+				}
 				out.Info("Opening %s in default editor", recordTime)
 				if err := t.EditRecordManual(recordTime); err != nil {
 					out.Err("Failed to edit record: %s", err.Error())

--- a/core/record.go
+++ b/core/record.go
@@ -93,14 +93,9 @@ func (t *Timetrace) SaveRecord(record Record, force bool) error {
 }
 
 // BackupRecord creates a backup of the given record file
-func (t *Timetrace) BackupRecord(recordKey time.Time) error {
-	path := t.fs.RecordFilepath(recordKey)
-	record, err := t.loadRecord(path)
-	if err != nil {
-		return err
-	}
+func (t *Timetrace) BackupRecord(record Record) error {
 	// create a new .bak filepath from the record struct
-	backupPath := t.fs.RecordBackupFilepath(recordKey)
+	backupPath := t.fs.RecordBackupFilepath(record.Start)
 
 	backupFile, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {


### PR DESCRIPTION
This PR resolves #89 .

Similar to #133 I had to rename the backup files to not have the `revert` functionality fail. Due to the change with the `BackupRecord` function, I think this PR might be best merged before #133 in the case that either PR needs adjustments.