### PR TITLE
resolved naming convention issue from #137

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,8 +525,8 @@ timetrace report
 |`--start <YYYY-MM-DD>`|`-s`|Filter report from a specific point in time (start is inclusive).|
 |`--end <YYYY-MM-DD>`|`-e`|Filter report to a specific point in time (end is inclusive).|
 |`--project <KEY>`|`-p`|Filter report for only one project.|
-|`--format <json>`|`-f`|Write report as JSON to file.|
-|`--out path/to/report`|`-o`|Write report to a specific file <br>(if not given will use config `report-dir`<br> if config not present writes to `$HOME/.timetrace/reports/report-<time.unix>`).|
+|`--output <json>`|`-o`|Write report as JSON to file.|
+|`--file path/to/report`|`-f`|Write report to a specific file <br>(if not given will use config `report-dir`<br> if config not present writes to `$HOME/.timetrace/reports/report-<time.unix>`).|
 
 ### Print version information
 

--- a/cli/report.go
+++ b/cli/report.go
@@ -14,7 +14,7 @@ type reportOptions struct {
 	isBillable   bool
 	projectKey   string
 	outputFormat string
-	outputPath   string
+	filePath     string
 	startTime    string
 	endTime      string
 }
@@ -75,7 +75,7 @@ func generateReportCommand(t *core.Timetrace) *cobra.Command {
 				if err != nil {
 					out.Err(err.Error())
 				}
-				t.WriteReport(options.outputPath, data)
+				t.WriteReport(options.filePath, data)
 			default:
 				projects, total := report.Table()
 				out.Table(
@@ -105,11 +105,11 @@ func generateReportCommand(t *core.Timetrace) *cobra.Command {
 	report.Flags().StringVarP(&options.projectKey, "project", "p",
 		"", "filter records by a specific project")
 
-	report.Flags().StringVarP(&options.outputFormat, "format", "f",
-		"print table", "output format for report (json/csv)")
+	report.Flags().StringVarP(&options.outputFormat, "output", "o",
+		"print table", "output format for report file (json)")
 
-	report.Flags().StringVarP(&options.outputPath, "out", "o",
-		"", "choose output path for report")
+	report.Flags().StringVarP(&options.filePath, "file", "f",
+		"", "file to write report to")
 
 	return report
 }


### PR DESCRIPTION
since the `timetrace status` command already specifies a naming convention for what `--output` and `--format` flags are supposed to do - the `report` command had to change accordingly. 