### PR TITLE
#151 create record validation if it is happened in future

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -89,7 +89,7 @@ func createRecordCommand(t *core.Timetrace) *cobra.Command {
 
 			now := time.Now()
 			if now.Before(start) || now.Before(end) {
-				out.Err("provided record happends in future!")
+				out.Err("provided record happens in the future!")
 				return
 			}
 

--- a/cli/create.go
+++ b/cli/create.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/dominikbraun/timetrace/core"
 	"github.com/dominikbraun/timetrace/out"
 
@@ -82,6 +84,12 @@ func createRecordCommand(t *core.Timetrace) *cobra.Command {
 
 			if end.Before(start) {
 				out.Err("end time is before start time!")
+				return
+			}
+
+			now := time.Now()
+			if now.Before(start) || now.Before(end) {
+				out.Err("provided record happends in future!")
 				return
 			}
 


### PR DESCRIPTION
PR for #151 

Added validation to `create` command to check if provided record happend after current timestamp.