### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ timetrace edit project <KEY>
 **Flags:**
 |Flag|Short|Description|
 |-|-|-|
-|`--revert`|`-r`|Revert the project to it's state prior to the last edit.|
+|`--revert`|`-r`|Revert the project to its state prior to the last edit.|
 
 **Example:**
 
@@ -421,7 +421,7 @@ Edit a project called `make-coffee`:
 timetrace edit project make-coffee
 ```
 
-:fire: **New:** Restore the project to it's state prior to the last edit:
+:fire: **New:** Restore the project to its state prior to the last edit:
 
 ```
 timetrace edit project make-coffee --revert
@@ -447,7 +447,7 @@ timetrace edit record {<KEY>|latest}
 |-|-|-|
 |`--plus`|`-p`|Add the given duration to the record's end time, e.g. `--plus 1h 10m`|
 |`--minus`|`-m`|Subtract the given duration from the record's end time, e.g. `--minus 1h 10m`|
-|`--revert`|`-r`|Revert the record to it's state prior to the last edit.|
+|`--revert`|`-r`|Revert the record to its state prior to the last edit.|
 
 **Example:**
 
@@ -463,7 +463,7 @@ Add 15 minutes to the end of the record created on May 1st, 3PM:
 timetrace edit record 2021-05-01-15-00 --plus 15m
 ```
 
-:fire: **New:** Restore the record to it's state prior to the last edit:
+:fire: **New:** Restore the record to its state prior to the last edit:
 
 ```
 timetrace edit record 2021-05-01-15-00 --revert
@@ -498,7 +498,7 @@ Delete a project called `make-coffee`:
 timetrace delete project make-coffee
 ```
 
-:fire: **New:** Restore the project to it's pre-deletion state:
+:fire: **New:** Restore the project to its pre-deletion state:
 
 ```
 timetrace delete project make-coffee --revert
@@ -531,7 +531,7 @@ Delete a record created on May 1st 2021, 3:00 PM:
 timetrace delete record 2021-05-01-15-00
 ```
 
-:fire: **New:** Restore the record to it's pre-deletion state:
+:fire: **New:** Restore the record to its pre-deletion state:
 
 ```
 timetrace delete record 2021-05-01-15-00 --revert

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -74,7 +74,7 @@ func deleteProjectCommand(t *core.Timetrace) *cobra.Command {
 		},
 	}
 
-	deleteProject.PersistentFlags().BoolVarP(&options.Revert, "revert", "r", false, "Restores the record to it's state prior to the last 'delete' command.")
+	deleteProject.PersistentFlags().BoolVarP(&options.Revert, "revert", "r", false, "Restores the record to its state prior to the last 'delete' command.")
 
 	return deleteProject
 }
@@ -133,7 +133,7 @@ func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
 		},
 	}
 
-	deleteRecord.PersistentFlags().BoolVarP(&options.Revert, "revert", "r", false, "Restores the record to it's state prior to the last 'delete' command.")
+	deleteRecord.PersistentFlags().BoolVarP(&options.Revert, "revert", "r", false, "Restores the record to its state prior to the last 'delete' command.")
 
 	return deleteRecord
 }

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -55,9 +55,11 @@ func deleteProjectCommand(t *core.Timetrace) *cobra.Command {
 				Key: key,
 			}
 
-			if !askForConfirmation() {
-				out.Info("Record NOT deleted.")
-				return
+			if !confirmed {
+				if !askForConfirmation() {
+					out.Info("Project NOT deleted.")
+					return
+				}
 			}
 
 			if err := t.BackupProject(key); err != nil {

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -42,12 +42,13 @@ func deleteProjectCommand(t *core.Timetrace) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			key := args[0]
+
 			if options.Revert {
 				if err := t.RevertProject(key); err != nil {
 					out.Err("Failed to revert project: %s", err.Error())
-				} else {
-					out.Info("Project backup restored successfully")
+					return
 				}
+				out.Info("Project backup restored successfully")
 				return
 			}
 
@@ -55,11 +56,9 @@ func deleteProjectCommand(t *core.Timetrace) *cobra.Command {
 				Key: key,
 			}
 
-			if !confirmed {
-				if !askForConfirmation() {
-					out.Info("Project NOT deleted.")
-					return
-				}
+			if !confirmed && !askForConfirmation() {
+				out.Info("Project NOT deleted.")
+				return
 			}
 
 			if err := t.BackupProject(key); err != nil {
@@ -101,9 +100,9 @@ func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
 			if options.Revert {
 				if err := t.RevertRecord(start); err != nil {
 					out.Err("Failed to revert record: %s", err.Error())
-				} else {
-					out.Info("Record backup restored successfully")
+					return
 				}
+				out.Info("Record backup restored successfully")
 				return
 			}
 
@@ -114,11 +113,10 @@ func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
 			}
 
 			showRecord(record, t.Formatter())
-			if !confirmed {
-				if !askForConfirmation() {
-					out.Info("Record NOT deleted.")
-					return
-				}
+
+			if !confirmed && !askForConfirmation() {
+				out.Info("Record NOT deleted.")
+				return
 			}
 
 			if err := t.BackupRecord(start); err != nil {


### PR DESCRIPTION
This PR addresses:

1. typos in the `--revert` help messages, change `it's` to `its`.
2. My earlier PR #147 failed to include the check for `--yes` flag in `deleteProjectCommand`. This PR fixes that.