### PR TITLE
added ignore case for loading records if file has a .bak extension

### DIFF
--- a/core/record.go
+++ b/core/record.go
@@ -299,6 +299,7 @@ func (t *Timetrace) loadOldestRecord(date time.Time) (*Record, error) {
 
 // loadFromRecordDir loads all records for one directory and returns them. The slice can be filtered
 // through the filter options.
+// !imporant: .bak files will be ignored by this function - only .json files in the directory will be read!
 func (t *Timetrace) loadFromRecordDir(recordDir string, filter ...func(*Record) bool) ([]*Record, error) {
 	filesInfo, err := ioutil.ReadDir(recordDir)
 	if err != nil {
@@ -308,6 +309,10 @@ func (t *Timetrace) loadFromRecordDir(recordDir string, filter ...func(*Record) 
 
 outer:
 	for _, info := range filesInfo {
+		// igonre backup file
+		if isBakFile(info.Name()) {
+			continue
+		}
 		record, err := t.loadRecord(filepath.Join(recordDir, info.Name()))
 		if err != nil {
 			return nil, err

--- a/core/timetrace.go
+++ b/core/timetrace.go
@@ -4,9 +4,14 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/dominikbraun/timetrace/config"
+)
+
+const (
+	BakFileExt = ".bak"
 )
 
 var (
@@ -307,4 +312,9 @@ func collides(toCheck Record, allRecords []*Record) bool {
 	}
 
 	return false
+}
+
+// isBackFile checks if a given filename is a backup-file
+func isBakFile(filename string) bool {
+	return filepath.Ext(filename) == BakFileExt
 }


### PR DESCRIPTION
Since the func `loadFromRecordDir` has changed its behaviour I double checked that there are no other places the function is currently used. For future reference I included a comment stating that the func will ignore `.bak` files.
closes point (2) from #161 