### PR TITLE
print more info when created record collides with others

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -106,7 +106,6 @@ func createRecordCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 			if collides {
-				out.Warn(" start and end of the record should not overlap with others")
 				return
 			}
 

--- a/cli/create.go
+++ b/cli/create.go
@@ -106,7 +106,7 @@ func createRecordCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 			if collides {
-				out.Err("Record collides with other record!")
+				out.Warn(" start and end of the record should not overlap with others")
 				return
 			}
 

--- a/core/timetrace.go
+++ b/core/timetrace.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/dominikbraun/timetrace/config"
+	"github.com/dominikbraun/timetrace/out"
 )
 
 const (
@@ -295,17 +296,24 @@ func (t *Timetrace) RecordCollides(toCheck Record) (bool, error) {
 }
 
 func collides(toCheck Record, allRecords []*Record) bool {
+	collide := false
 	for _, rec := range allRecords {
 		if rec.End != nil && rec.Start.Before(*toCheck.End) && rec.End.After(toCheck.Start) {
-			return true
+			defer out.Info("%v %v-%v", rec.Project.Key, rec.Start.String(), rec.End.String())
+			collide = true
 		}
 
 		if rec.End == nil && toCheck.End.After(rec.Start) {
-			return true
+			defer out.Info("%v %v-%v", rec.Project.Key, rec.Start.String(), rec.End.String())
+			collide = true
 		}
 	}
 
-	return false
+	if collide {
+		out.Err("collides with these records :")
+	}
+
+	return collide
 }
 
 // isBackFile checks if a given filename is a backup-file

--- a/core/timetrace.go
+++ b/core/timetrace.go
@@ -275,7 +275,7 @@ func (t *Timetrace) latestNonEmptyDir(dirs []string) (string, error) {
 	return "", ErrAllDirectoriesEmpty
 }
 
-func printCollides(t *Timetrace, records []*Record) {
+func printCollisions(t *Timetrace, records []*Record) {
 	out.Err("collides with these records :")
 
 	rows := make([][]string, len(records))
@@ -326,7 +326,7 @@ func (t *Timetrace) RecordCollides(toCheck Record) (bool, error) {
 
 	collide, collidingRecords := collides(toCheck, allRecords)
 	if collide {
-		printCollides(t, collidingRecords)
+		printCollisions(t, collidingRecords)
 	}
 
 	return collide, nil

--- a/core/timetrace.go
+++ b/core/timetrace.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/dominikbraun/timetrace/config"
@@ -274,6 +275,37 @@ func (t *Timetrace) latestNonEmptyDir(dirs []string) (string, error) {
 	return "", ErrAllDirectoriesEmpty
 }
 
+func printCollides(t *Timetrace, records []*Record) {
+	out.Err("collides with these records :")
+
+	rows := make([][]string, len(records))
+
+	for i, record := range records {
+		end := "still running"
+		if record.End != nil {
+			end = t.Formatter().TimeString(*record.End)
+		}
+
+		billable := "no"
+
+		if record.IsBillable {
+			billable = "yes"
+		}
+
+		rows[i] = make([]string, 6)
+		rows[i][0] = strconv.Itoa(i + 1)
+		rows[i][1] = t.Formatter().RecordKey(record)
+		rows[i][2] = record.Project.Key
+		rows[i][3] = t.Formatter().TimeString(record.Start)
+		rows[i][4] = end
+		rows[i][5] = billable
+	}
+
+	out.Table([]string{"#", "Key", "Project", "Start", "End", "Billable"}, rows, []string{})
+
+	out.Warn(" start and end of the record should not overlap with others")
+}
+
 // RecordCollides checks if the time of a record collides
 // with other records of the same day and returns a bool
 func (t *Timetrace) RecordCollides(toCheck Record) (bool, error) {
@@ -292,36 +324,31 @@ func (t *Timetrace) RecordCollides(toCheck Record) (bool, error) {
 		}
 	}
 
-	return collides(toCheck, allRecords), nil
+	collide, collidingRecords := collides(toCheck, allRecords)
+	if collide {
+		printCollides(t, collidingRecords)
+	}
+
+	return collide, nil
 }
 
-func collides(toCheck Record, allRecords []*Record) bool {
+func collides(toCheck Record, allRecords []*Record) (bool, []*Record) {
 	collide := false
+	collidingRecords := make([]*Record, 0)
 	for _, rec := range allRecords {
-		var project, end string
-		if rec.Project != nil {
-			project = rec.Project.Key
-		}
-		if rec.End != nil {
-			end = rec.End.String()
-		}
 
 		if rec.End != nil && rec.Start.Before(*toCheck.End) && rec.End.After(toCheck.Start) {
-			defer out.Info("%v %v-%v", project, rec.Start.String(), end)
+			collidingRecords = append(collidingRecords, rec)
 			collide = true
 		}
 
 		if rec.End == nil && toCheck.End.After(rec.Start) {
-			defer out.Info("%v %v-%v", project, rec.Start.String(), end)
+			collidingRecords = append(collidingRecords, rec)
 			collide = true
 		}
 	}
 
-	if collide {
-		out.Err("collides with these records :")
-	}
-
-	return collide
+	return collide, collidingRecords
 }
 
 // isBackFile checks if a given filename is a backup-file

--- a/core/timetrace.go
+++ b/core/timetrace.go
@@ -298,13 +298,21 @@ func (t *Timetrace) RecordCollides(toCheck Record) (bool, error) {
 func collides(toCheck Record, allRecords []*Record) bool {
 	collide := false
 	for _, rec := range allRecords {
+		var project, end string
+		if rec.Project != nil {
+			project = rec.Project.Key
+		}
+		if rec.End != nil {
+			end = rec.End.String()
+		}
+
 		if rec.End != nil && rec.Start.Before(*toCheck.End) && rec.End.After(toCheck.Start) {
-			defer out.Info("%v %v-%v", rec.Project.Key, rec.Start.String(), rec.End.String())
+			defer out.Info("%v %v-%v", project, rec.Start.String(), end)
 			collide = true
 		}
 
 		if rec.End == nil && toCheck.End.After(rec.Start) {
-			defer out.Info("%v %v-%v", rec.Project.Key, rec.Start.String(), rec.End.String())
+			defer out.Info("%v %v-%v", project, rec.Start.String(), end)
 			collide = true
 		}
 	}

--- a/core/timetrace_test.go
+++ b/core/timetrace_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -16,6 +17,19 @@ func newTestRecTracked(s int) Record {
 	return Record{Start: start}
 }
 
+func checkConsistent(t *testing.T, expect, result []*Record) {
+	if !reflect.DeepEqual(result, expect) {
+		t.Errorf("should collide with :\n")
+		for _, r := range expect {
+			t.Errorf("%v\n", r)
+		}
+		t.Errorf("while collides return :\n")
+		for _, r := range result {
+			t.Errorf("%v\n", r)
+		}
+	}
+}
+
 func TestCollides(t *testing.T) {
 	savedRec := newTestRecord(-60, -1)
 	allRecs := []*Record{&savedRec}
@@ -25,77 +39,93 @@ func TestCollides(t *testing.T) {
 	// rec1 starts and end after savedRec
 	rec1 := newTestRecord(-1, 0)
 
-	if collide, _ := collides(rec1, allRecs); collide {
+	if collide, collidingRecs := collides(rec1, allRecs); collide && len(collidingRecs) == 0 {
 		t.Error("records should not collide")
 	}
 
 	// rec2 starts in savedRec, ends after
 	rec2 := newTestRecord(-30, 1)
 
-	if collide, _ := collides(rec2, allRecs); !collide {
+	if collide, collidingRecs := collides(rec2, allRecs); !collide {
 		t.Error("records should collide")
+	} else {
+		checkConsistent(t, allRecs, collidingRecs)
 	}
 
 	// rec3 start before savedRec, ends inside
 	rec3 := newTestRecord(-75, -30)
 
-	if collide, _ := collides(rec3, allRecs); !collide {
+	if collide, collidingRecs := collides(rec3, allRecs); !collide {
 		t.Error("records should collide")
+	} else {
+		checkConsistent(t, allRecs, collidingRecs)
 	}
 
 	// rec4 starts and ends before savedRec
 	rec4 := newTestRecord(-75, -70)
 
-	if collide, _ := collides(rec4, allRecs); collide {
+	if collide, collidingRecs := collides(rec4, allRecs); collide && len(collidingRecs) == 0 {
 		t.Error("records should not collide")
 	}
 
 	// rec5 starts and ends inside savedRec
 	rec5 := newTestRecord(-40, -20)
 
-	if collide, _ := collides(rec5, allRecs); !collide {
+	if collide, collidingRecs := collides(rec5, allRecs); !collide {
 		t.Error("records should collide")
+	} else {
+		checkConsistent(t, allRecs, collidingRecs)
 	}
 
 	// rec6 starts before and ends after savedRec
 	rec6 := newTestRecord(-70, 10)
 
-	if collide, _ := collides(rec6, allRecs); !collide {
+	if collide, collidingRecs := collides(rec6, allRecs); !collide {
 		t.Error("records should collide")
+	} else {
+		checkConsistent(t, allRecs, collidingRecs)
 	}
 
 	// rec7 starts and ends at the same time as savedRec
 	rec7 := newTestRecord(-60, -1)
 
-	if collide, _ := collides(rec7, allRecs); !collide {
+	if collide, collidingRecs := collides(rec7, allRecs); !collide {
 		t.Error("records should collide")
+	} else {
+		checkConsistent(t, allRecs, collidingRecs)
 	}
 
 	// rec7 starts at the same time as savedRecTracked
 	rec8 := newTestRecord(-60, -1)
 
-	if collide, _ := collides(rec8, allRecsTracked); !collide {
+	if collide, collidingRecs := collides(rec8, allRecsTracked); !collide {
 		t.Error("records should collide")
+	} else {
+		checkConsistent(t, allRecsTracked, collidingRecs)
 	}
 
 	// rec9 ends at the time savedRecTracked ends
 	rec9 := newTestRecord(-80, -60)
 
-	if collide, _ := collides(rec9, allRecsTracked); !collide {
+	if collide, collidingRecs := collides(rec9, allRecsTracked); !collide {
 		t.Error("records should collide")
+	} else {
+		checkConsistent(t, allRecsTracked, collidingRecs)
 	}
 
 	// rec10 ends after savedRecTracked starts
 	rec10 := newTestRecord(-80, -50)
 
-	if collide, _ := collides(rec10, allRecsTracked); !collide {
+	if collide, collidingRecs := collides(rec10, allRecsTracked); !collide {
 		t.Error("records should collide")
+	} else {
+		checkConsistent(t, allRecsTracked, collidingRecs)
 	}
 
 	// rec11 ends before savedRecTracked starts
 	rec11 := newTestRecord(-80, -70)
 
-	if collide, _ := collides(rec11, allRecsTracked); collide {
+	if collide, collidingRecs := collides(rec11, allRecsTracked); collide && len(collidingRecs) == 0 {
 		t.Error("records should not collide")
 	}
 }

--- a/core/timetrace_test.go
+++ b/core/timetrace_test.go
@@ -25,77 +25,77 @@ func TestCollides(t *testing.T) {
 	// rec1 starts and end after savedRec
 	rec1 := newTestRecord(-1, 0)
 
-	if collides(rec1, allRecs) {
+	if collide, _ := collides(rec1, allRecs); collide {
 		t.Error("records should not collide")
 	}
 
 	// rec2 starts in savedRec, ends after
 	rec2 := newTestRecord(-30, 1)
 
-	if !collides(rec2, allRecs) {
+	if collide, _ := collides(rec2, allRecs); !collide {
 		t.Error("records should collide")
 	}
 
 	// rec3 start before savedRec, ends inside
 	rec3 := newTestRecord(-75, -30)
 
-	if !collides(rec3, allRecs) {
+	if collide, _ := collides(rec3, allRecs); !collide {
 		t.Error("records should collide")
 	}
 
 	// rec4 starts and ends before savedRec
 	rec4 := newTestRecord(-75, -70)
 
-	if collides(rec4, allRecs) {
+	if collide, _ := collides(rec4, allRecs); collide {
 		t.Error("records should not collide")
 	}
 
 	// rec5 starts and ends inside savedRec
 	rec5 := newTestRecord(-40, -20)
 
-	if !collides(rec5, allRecs) {
+	if collide, _ := collides(rec5, allRecs); !collide {
 		t.Error("records should collide")
 	}
 
 	// rec6 starts before and ends after savedRec
 	rec6 := newTestRecord(-70, 10)
 
-	if !collides(rec6, allRecs) {
+	if collide, _ := collides(rec6, allRecs); !collide {
 		t.Error("records should collide")
 	}
 
 	// rec7 starts and ends at the same time as savedRec
 	rec7 := newTestRecord(-60, -1)
 
-	if !collides(rec7, allRecs) {
+	if collide, _ := collides(rec7, allRecs); !collide {
 		t.Error("records should collide")
 	}
 
 	// rec7 starts at the same time as savedRecTracked
 	rec8 := newTestRecord(-60, -1)
 
-	if !collides(rec8, allRecsTracked) {
+	if collide, _ := collides(rec8, allRecsTracked); !collide {
 		t.Error("records should collide")
 	}
 
 	// rec9 ends at the time savedRecTracked ends
 	rec9 := newTestRecord(-80, -60)
 
-	if !collides(rec9, allRecsTracked) {
+	if collide, _ := collides(rec9, allRecsTracked); !collide {
 		t.Error("records should collide")
 	}
 
 	// rec10 ends after savedRecTracked starts
 	rec10 := newTestRecord(-80, -50)
 
-	if !collides(rec10, allRecsTracked) {
+	if collide, _ := collides(rec10, allRecsTracked); !collide {
 		t.Error("records should collide")
 	}
 
 	// rec11 ends before savedRecTracked starts
 	rec11 := newTestRecord(-80, -70)
 
-	if collides(rec11, allRecsTracked) {
+	if collide, _ := collides(rec11, allRecsTracked); collide {
 		t.Error("records should not collide")
 	}
 }

--- a/core/timetrace_test.go
+++ b/core/timetrace_test.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"reflect"
 	"testing"
 	"time"
 )
@@ -18,7 +17,18 @@ func newTestRecTracked(s int) Record {
 }
 
 func checkConsistent(t *testing.T, expect, result []*Record) {
-	if !reflect.DeepEqual(result, expect) {
+	sameLen := len(result) == len(expect)
+	sameContent := true
+
+	if sameLen {
+		for i := range result {
+			if expect[i] != result[i] {
+				sameContent = false
+			}
+		}
+	}
+
+	if !(sameLen && sameContent) {
 		t.Errorf("should collide with :\n")
 		for _, r := range expect {
 			t.Errorf("%v\n", r)
@@ -28,6 +38,7 @@ func checkConsistent(t *testing.T, expect, result []*Record) {
 			t.Errorf("%v\n", r)
 		}
 	}
+
 }
 
 func TestCollides(t *testing.T) {


### PR DESCRIPTION
resolve #173 
first PR in this repo
I simply changed/added some print statements
any feedback will be appreciated

now the output is
```
❯ go run . create record open-summer today 8:25 10:30
❗ collides with these records :
💡 open-summer 2021-08-28 08:21:00 +0800 CST-2021-08-28 09:23:00 +0800 CST
💡 open-summer 2021-08-28 09:30:00 +0800 CST-2021-08-28 10:20:00 +0800 CST
⚠️  start and end of the record should not overlap with others

```