### PR TITLE
Check record collisions before editing a record

### DIFF
--- a/cli/edit.go
+++ b/cli/edit.go
@@ -90,6 +90,19 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 
+			// checking if there is a record time collision before actually editing it
+			record := core.Record{
+				Start: recordTime,
+			}
+			collides, err := t.RecordCollides(record)
+			if err != nil {
+				out.Err("Error on check if record collides: %s", err.Error())
+				return
+			}
+			if collides {
+				return
+			}
+
 			if options.Revert {
 				if err := t.RevertRecord(recordTime); err != nil {
 					out.Err("Failed to revert record: %s", err.Error())


### PR DESCRIPTION
This PR adds a fix to check if a time collision happens before enabling editing the record.
Fixes #187 