### PR TITLE
Change help text for `timetrace create record` to honor `use12hours`

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -50,8 +50,14 @@ func createProjectCommand(t *core.Timetrace) *cobra.Command {
 
 func createRecordCommand(t *core.Timetrace) *cobra.Command {
 	var options startOptions
+	var usage string
+	if t.Config().Use12Hours {
+		usage = "record <PROJECT KEY> {<YYYY-MM-DD>|today|yesterday} <HH:MMPM> <HH:MMPM>"
+	} else {
+		usage = "record <PROJECT KEY> {<YYYY-MM-DD>|today|yesterday} <HH:MM> <HH:MM>"
+	}
 	createRecord := &cobra.Command{
-		Use:   "record <PROJECT KEY> {<YYYY-MM-DD>|today|yesterday} <HH:MM> <HH:MM>",
+		Use:   usage,
 		Short: "Create a new record",
 		Args:  cobra.ExactArgs(4),
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Fixes #190.

Using `Use12Hours` in `core.Timetrace.Config()` to use a different string for the usage help text for `timetrace create record`.

### Behaviour

#### `use12hours: false` in `config.yaml`

```txt
Create a new record
  timetrace create record <PROJECT KEY> {<YYYY-MM-DD>|today|yesterday} <HH:MM> <HH:MM> [flags]

Flags:
  -b, --billable   mark tracked time as billable
  -h, --help       help for record
```

#### `use12hours: true` in `config.yaml`

```txt
Create a new record
  timetrace create record <PROJECT KEY> {<YYYY-MM-DD>|today|yesterday} <HH:MMPM> <HH:MMPM> [flags]

Flags:
  -b, --billable   mark tracked time as billable
  -h, --help       help for record
```