### PR TITLE
limit number of tags to 3

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -27,6 +27,12 @@ func startCommand(t *core.Timetrace) *cobra.Command {
 			projectKey := args[0]
 			tags := args[1:]
 
+			// Limit number of tags to 3
+			if len(tags) > 3 {
+				out.Err("Failed to start tracking: At most 3 tags are allowed, got %v tags", len(tags))
+				return
+			}
+
 			isBillable := options.isBillable
 
 			// If there is a default configuration for the project key, use that configuration.


### PR DESCRIPTION
Limits the number of tags to 3 for timetrace start

Fix #188 