### PR TITLE
Fix start command panic when ran with no args

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -23,6 +23,7 @@ func startCommand(t *core.Timetrace) *cobra.Command {
 	start := &cobra.Command{
 		Use:   "start <PROJECT KEY> [+TAG1, +TAG2, ...]",
 		Short: "Start tracking time",
+		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			projectKey := args[0]
 			tags := args[1:]


### PR DESCRIPTION
This sets the minimum number of arguments for the start
command to 1.

Fixes #198