### PR TITLE
Report improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,14 +602,14 @@ timetrace report
 **Flags:**
 
 | Flag                    | Short | Description                                                                                                                                                        |
-| ----------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--billable`            | `-b`  | Filter report for only billable records.                                                                                                                           |
-| `--non-billable`        |       | Filter report for non-billable records.                                                                                                                            |
-| `--start <YYYY-MM-DD>`  | `-s`  | Filter report from a specific point in time (start is inclusive).                                                                                                  |
-| `--end <YYYY-MM-DD>`    | `-e`  | Filter report to a specific point in time (end is inclusive).                                                                                                      |
-| `--project <KEY>`       | `-p`  | Filter report for only one project.                                                                                                                                |
-| `--output <json>`       | `-o`  | Write report as JSON to file.                                                                                                                                      |
-| `--file path/to/report` | `-f`  | Write report to a specific file <br>(if not given will use config `report-dir`<br> if config not present writes to `$HOME/.timetrace/reports/report-<time.unix>`). |
+| ------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--billable`              | `-b`  | Filter report for only billable records.                                                                                                                           |
+| `--non-billable`          |       | Filter report for non-billable records.                                                                                                                            |
+| `--start <YYYY-MM-DD>`    | `-s`  | Filter report from a specific point in time (start is inclusive).                                                                                                  |
+| `--end <YYYY-MM-DD>`      | `-e`  | Filter report to a specific point in time (end is inclusive).                                                                                                      |
+| `--project <KEY>`         | `-p`  | Filter report for only one project.                                                                                                                                |
+| `--output <FORMAT>`       | `-o`  | Write report to file. Valid values: `json` or `csv`                                                                                                                |
+| `--file path/to/report`   | `-f`  | Write report to a specific file <br>(if not given will use config `report-dir`<br> if config not present writes to `$HOME/.timetrace/reports/report-<time.unix>`). |
 
 ### Print version information
 

--- a/cli/report.go
+++ b/cli/report.go
@@ -88,12 +88,12 @@ func generateReportCommand(t *core.Timetrace) *cobra.Command {
 			default:
 				projects, total := report.Table()
 				out.Table(
-					[]string{"Project", "Module", "Date", "Start", "End", "Billable", "Total"},
+					[]string{"Project", "Module", "Date", "Start", "End", "Duration", "Billable", "Total"},
 					projects,
-					[]string{"", "", "", "", "", "TOTAL", total},
+					[]string{"", "", "", "", "", "", "TOTAL", total},
 					out.TableWithCellMerge(0), // merge cells over "Project" (index:0) column
 					out.TableFooterColor(
-						tablewriter.Colors{}, tablewriter.Colors{},
+						tablewriter.Colors{}, tablewriter.Colors{}, tablewriter.Colors{},
 						tablewriter.Colors{}, tablewriter.Colors{}, tablewriter.Colors{},
 						tablewriter.Colors{tablewriter.Bold},          // text "TOTAL"
 						tablewriter.Colors{tablewriter.FgGreenColor}), // digit of "TOTAL"

--- a/cli/report.go
+++ b/cli/report.go
@@ -85,10 +85,16 @@ func generateReportCommand(t *core.Timetrace) *cobra.Command {
 					out.Err(err.Error())
 				}
 				t.WriteReport(options.filePath, data)
+			case "csv":
+				data, err := report.CSV()
+				if err != nil {
+					out.Err(err.Error())
+				}
+				t.WriteReport(options.filePath, data)
 			default:
 				projects, total := report.Table()
 				out.Table(
-					[]string{"Project", "Module", "Date", "Start", "End", "Duration", "Billable", "Total"},
+					core.GetHeaderColumns(options.outputFormat),
 					projects,
 					[]string{"", "", "", "", "", "", "TOTAL", total},
 					out.TableWithCellMerge(0), // merge cells over "Project" (index:0) column

--- a/core/formatter.go
+++ b/core/formatter.go
@@ -52,6 +52,7 @@ const (
 	defaultTimeLayout        = "15:04"
 	default12HoursTimeLayout = "03:04PM"
 	defaultDatelayoutPretty  = "Monday, 02. January 2006"
+	defaultDurationLayout	 = time.Second
 )
 
 func (f *Formatter) timeLayout() string {
@@ -61,8 +62,16 @@ func (f *Formatter) timeLayout() string {
 	return defaultTimeLayout
 }
 
+func (f *Formatter) durationLayout() time.Duration {
+	return defaultDurationLayout
+}
+
 func (f *Formatter) TimeString(input time.Time) string {
 	return input.Format(f.timeLayout())
+}
+
+func (f *Formatter) DurationString(input time.Duration) string {
+	return input.Truncate(f.durationLayout()).String()
 }
 
 // PrettyDateString returns a nice representation of a given time

--- a/core/formatter.go
+++ b/core/formatter.go
@@ -52,7 +52,7 @@ const (
 	defaultTimeLayout        = "15:04"
 	default12HoursTimeLayout = "03:04PM"
 	defaultDatelayoutPretty  = "Monday, 02. January 2006"
-	defaultDurationLayout	 = time.Second
+	defaultDurationLayout	 = time.Minute
 )
 
 func (f *Formatter) timeLayout() string {
@@ -71,7 +71,7 @@ func (f *Formatter) TimeString(input time.Time) string {
 }
 
 func (f *Formatter) DurationString(input time.Duration) string {
-	return input.Truncate(f.durationLayout()).String()
+	return input.Round(f.durationLayout()).String()
 }
 
 // PrettyDateString returns a nice representation of a given time

--- a/core/reporter.go
+++ b/core/reporter.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -11,8 +13,22 @@ const (
 	defaultTotalSymbol = "∑"
 )
 
+
 func FilterNoneNilEndTime(r *Record) bool {
 	return r.End != nil
+}
+
+// GetHeaderColumns return the header columns for a table print
+// or a CSV export
+func GetHeaderColumns(outputFormat string) []string {
+	switch outputFormat {
+		case "table":
+			return []string{"Project", "Module", "Date", "Start", "End", "Duration", "Billable", "Total"}
+		case "csv":
+			return []string{"Project", "Module", "Date", "Start", "End", "Duration", "Billable"}
+		default:
+			return []string{"Project", "Module", "Date", "Start", "End", "Duration", "Billable", "Total"}
+	}
 }
 
 // FilterBillable returns a record filter for the billable flag
@@ -158,4 +174,42 @@ func (r Reporter) Json() ([]byte, error) {
 		return nil, fmt.Errorf("could not marshal report to json")
 	}
 	return b, nil
+}
+
+// CSV prepares the r.report and r.totals data so that it can be written to a csv file
+func (r Reporter) CSV() ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+
+	// Writing the header
+	writer.Write(GetHeaderColumns("csv"))
+
+	for _, records := range r.report {
+		for _, record := range records {
+			keyParts := strings.Split(record.Project.Key, "@")
+			module, key := "", keyParts[0]
+			if len(keyParts) > 1 {
+				module = keyParts[0]
+				key = keyParts[1]
+			}
+			billable := "no"
+			if record.IsBillable {
+				billable = "yes"
+			}
+			date := r.t.Formatter().PrettyDateString(record.Start)
+			start := r.t.Formatter().TimeString(record.Start)
+			end := r.t.Formatter().TimeString(*record.End)
+
+			duration := r.t.Formatter().DurationString(record.End.Sub(record.Start))
+
+			writer.Write([]string{key, module, date, start, end, duration, billable, ""})
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, fmt.Errorf("error while writing to buffer")
+	}
+
+	return buffer.Bytes(), nil
 }

--- a/core/reporter.go
+++ b/core/reporter.go
@@ -128,10 +128,12 @@ func (r Reporter) Table() ([][]string, string) {
 			start := r.t.Formatter().TimeString(record.Start)
 			end := r.t.Formatter().TimeString(*record.End)
 
-			rows = append(rows, []string{key, module, date, start, end, billable, ""})
+			duration := r.t.Formatter().DurationString(record.End.Sub(record.Start))
+
+			rows = append(rows, []string{key, module, date, start, end, duration, billable, ""})
 		}
 		// append with last row for total of tracked time for project
-		rows = append(rows, []string{"", "", "", "", "", defaultTotalSymbol, r.t.Formatter().FormatDuration(r.totals[key])})
+		rows = append(rows, []string{"", "", "", "", "", "", defaultTotalSymbol, r.t.Formatter().FormatDuration(r.totals[key])})
 		totalSum += r.totals[key]
 	}
 	return rows, r.t.Formatter().FormatDuration(totalSum)


### PR DESCRIPTION
Adding the CSV export for the report command.

Adding a duration column in the report command that is the time spent for each record. I've found this useful on top of the total to quickly see how long each record took.