### PR TITLE
Modify installation command using scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ yay -S timetrace-bin
 ### Scoop
 
 ```
-scoop bucket add https://github.com/Br1ght0ne/scoop-bucket
+scoop bucket add <name> https://github.com/Br1ght0ne/scoop-bucket
 scoop install timetrace
 ```
 


### PR DESCRIPTION
As [this](https://scoop-docs.vercel.app/docs/concepts/Buckets.html#installing-from-other-buckets) suggests, you need to provide a name when adding a bucket:
`scoop bucket add <name-of-bucket> <location-of-git-repo>`