### PR TITLE
Avoid circleci fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: cimg/python:3.9.7
   go-container:
     docker:
-      - image: cimg/go:1.17.1
+      - image: cimg/go:1.21.6
     environment:
       GO111MODULE: "on"
       GOPROXY: "https://proxy.golang.org"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 executors:
   python-container:
-   docker:
-    - image: cimg/python:3.9.7
+    docker:
+      - image: cimg/python:3.9.7
   go-container:
     docker:
       - image: cimg/go:1.17.1
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Install goimports tool
           command: |
-            go get -u golang.org/x/tools/cmd/goimports
+            go install golang.org/x/tools/cmd/goimports@latest
             echo "export PATH=$GOPATH/bin:$PATH" >> $BASH_ENV
       - run:
           name: Check Go format


### PR DESCRIPTION
I attempted a quick fix as I saw that circleci is complaining on the `go get -u` istruction ad thus failing to do its checks

NB: I didn't notice #196, you can ignore this if this is not useful. In any case whatever the solution will be it will be better than having that "failed" status while the tests are green 😅