### PR TITLE
fixing edit record manually creating inconsisten file name / start time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+timetrace
 
 # IDE directories
 .idea

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -167,10 +167,10 @@ func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
 }
 
 func askForConfirmation(msg string) bool {
-	reader := bufio.NewReader(os.Stdin)
+	scanner := bufio.NewScanner(os.Stdin)
 	fmt.Fprint(os.Stderr, msg)
-	s, _ := reader.ReadString('\n')
-	s = strings.TrimSuffix(s, "\n")
+	scanner.Scan()
+	s := scanner.Text()
 	s = strings.ToLower(s)
 
 	return s == "y"

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -114,7 +114,7 @@ func deleteRecordCommand(t *core.Timetrace) *cobra.Command {
 				}
 			}
 
-			if err := t.BackupRecord(start); err != nil {
+			if err := t.BackupRecord(*record); err != nil {
 				out.Err("Failed to backup record before deletion: %s", err.Error())
 				return
 			}

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -84,9 +84,10 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 
 			var recordTime time.Time
 			var err error
+			var rec *core.Record
 			// if more aliases are needed, this should be expanded to a switch
 			if strings.ToLower(args[0]) == "latest" {
-				rec, err := t.LoadLatestRecord()
+				rec, err = t.LoadLatestRecord()
 				if err != nil {
 					out.Err("Error on loading last record: %s", err.Error())
 					return
@@ -96,6 +97,10 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				recordTime, err = t.Formatter().ParseRecordKey(args[0])
 				if err != nil {
 					out.Err("Failed to parse date argument: %s", err.Error())
+					return
+				}
+				rec, err = t.LoadRecord(recordTime)
+				if err != nil {
 					return
 				}
 			}
@@ -109,7 +114,7 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 				return
 			}
 
-			if err := t.BackupRecord(recordTime); err != nil {
+			if err := t.BackupRecord(*rec); err != nil {
 				out.Err("Failed to backup record before edit: %s", err.Error())
 				return
 			}

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -120,6 +121,11 @@ func editRecordCommand(t *core.Timetrace) *cobra.Command {
 			}
 
 			if options.Minus == "" && options.Plus == "" {
+				fmt.Printf("Warning: Directly editing the record can lead to undefined behavior.\nIf you change the start time of the record, the underlying file will be renamed automatically. Make sure it doesn't collide with other records. If you want to change the end time, use --minus or --plus instead.\nContinue? ")
+				if !askForConfirmation() {
+					out.Info("Editting record aborted.")
+					return
+				}
 				out.Info("Opening %s in default editor", recordTime)
 				if err := t.EditRecordManual(recordTime); err != nil {
 					out.Err("Failed to edit record: %s", err.Error())

--- a/core/record.go
+++ b/core/record.go
@@ -251,9 +251,10 @@ func (t *Timetrace) DeleteRecordsByProject(key string) error {
 }
 
 // EditRecordManual opens the record file in the preferred or default editor.
+// note we don't rename the backup, because it could have inconsistency between 
+// start time and file name
 func (t *Timetrace) EditRecordManual(recordTime time.Time) error {
 	path := t.fs.RecordFilepath(recordTime)
-	backupPath := t.fs.RecordBackupFilepath(recordTime)
 
 	rec, err := t.loadRecord(path)
 	if err != nil {
@@ -282,13 +283,8 @@ func (t *Timetrace) EditRecordManual(recordTime time.Time) error {
 	}
 
 	newPath := t.fs.RecordFilepath(newStart)
-	newBackupPath := t.fs.RecordBackupFilepath(newStart)
 
-	if err = os.Rename(path, newPath); err != nil {
-		return err
-	}
-
-	return os.Rename(backupPath, newBackupPath)
+	return os.Rename(path, newPath)
 }
 
 // EditRecord loads the record internally, applies the option values and saves the record

--- a/core/record.go
+++ b/core/record.go
@@ -93,14 +93,9 @@ func (t *Timetrace) SaveRecord(record Record, force bool) error {
 }
 
 // BackupRecord creates a backup of the given record file
-func (t *Timetrace) BackupRecord(recordKey time.Time) error {
-	path := t.fs.RecordFilepath(recordKey)
-	record, err := t.loadRecord(path)
-	if err != nil {
-		return err
-	}
+func (t *Timetrace) BackupRecord(record Record) error {
 	// create a new .bak filepath from the record struct
-	backupPath := t.fs.RecordBackupFilepath(recordKey)
+	backupPath := t.fs.RecordBackupFilepath(record.Start)
 
 	backupFile, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {


### PR DESCRIPTION
Fixes #246 and #89 
based on @joshuaherrera 's fix, with the following changes:
- the new manual edit does not rename the backup file, as it could cause the backup file to be inconsistent (start time <> file name)
- fixed small bug in askForConfirmation function that did not deal with Windows style new lines ("\r\n")